### PR TITLE
actually make get_system_volume work

### DIFF
--- a/bypass-mdm-v2.sh
+++ b/bypass-mdm-v2.sh
@@ -11,12 +11,13 @@ NC='\033[0m'
 
 # Function to get the system volume name
 get_system_volume() {
-    system_volume=$(diskutil info / | grep "Device Node" | awk -F': ' '{print $2}' | xargs diskutil info | grep "Volume Name" | awk -F': ' '{print $2}' | tr -d ' ')
+    system_volume=$(diskutil info / | grep "Volume Name:" | awk -F': ' '{print $2}' | xargs)
     echo "$system_volume"
 }
 
 # Get the system volume name
 system_volume=$(get_system_volume)
+
 
 # Display header
 echo -e "${CYAN}Bypass MDM By Assaf Dori (assafdori.com)${NC}"


### PR DESCRIPTION
The way you had it before:

it would return MacintoshHD vs Machintosh HD

Ill show you command results here:

❯ diskutil info / | grep "Device Node" | awk -F': ' '{print $2}' | xargs diskutil info | grep "Volume Name" | awk -F': ' '{print $2}' | tr -d ' '
MacintoshHD

when in-fact the real name is:
❯ diskutil info / | grep "Device Node" | awk -F': ' '{print $2}' | xargs diskutil info | grep "Volume Name"
   Volume Name:               Macintosh HD


and my way is much more simple:

❯ diskutil info / | grep "Volume Name:" | awk -F': ' '{print $2}' | xargs
Macintosh HD