### PR TITLE
New Feature: Local MDM Bypass for Dual-Boot macOS Setups (with sudo access)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,27 @@
 
 ![mdm-screen](https://raw.githubusercontent.com/assafdori/bypass-mdm/main/mdm-screen.png)
 
-#### Prerequisites ⚠️
+### Table of Contents 📚
 
-- **It is advised to erase the hard-drive prior to starting.**
-- **It is advised to re-install MacOS using an external flash drive.**
-- **Device language needs to be set to English, it can be changed afterwards.**
+- [Prerequisites ⚠️](#prerequisites-⚠️)
+- [Bypass MDM via Recovery](#bypass-mdm-via-recovery)
+- [Bypass MDM with Sudo Privileges](#bypass-mdm-with-sudo-privileges)
+- [Final Notes](#final-notes)
 
+---
+
+### Prerequisites ⚠️
+
+- **Bypass MDM via Recovery**
+    - **It is advised to erase the hard-drive prior to starting.**
+    - **It is advised to re-install MacOS using an external flash drive.**
+    - **Device language needs to be set to English, it can be changed afterwards.**
+    - **Make sure the partition is named Macintosh HD**
+- **Bypass MDM with Sudo Privileges**
+    - **Create a new partition**
+    - **It is advised to start with a fresh install**
+
+### Bypass MDM via Recovery
 
 #### Follow steps below to bypass MDM setup during a fresh installation of MacOS
 
@@ -58,4 +73,66 @@ curl https://raw.githubusercontent.com/assafdori/bypass-mdm/main/bypass-mdm.sh -
 
 19. Congratulations, you're MDM free! 💫
 
-###### Although it's virtually impossible to catch that you've removed the MDM (because it wasn't even configured), be aware that the serial number of the laptop will still be shown in the inventory system of your company. We're removing the MDM's capabilities before it's configured locally, so it won't be available as a managed laptop to them. Use with caution. Probably a good idea to have a valid excuse as well.
+### Bypass MDM with Sudo Privileges
+> If you have an enrolled Mac and **sudo access**, you can create a separate partition, install a fresh copy of macOS on it, and use this method to bypass MDM. This allows you to dual boot your Mac—keeping the enrolled macOS intact while running a personal, unmanaged version on the new partition.
+
+#### Follow steps below to bypass MDM setup during a fresh installation of MacOS
+
+1. Create a new partition. [Official Apple guide.](https://support.apple.com/en-us/118282)
+
+2. Download the latest macOS Installer from the App Store
+
+3. Install macOS and follow the onscreen instructions
+
+> Upon arriving to the setup stage of forced MDM enrollement:
+
+4. Long press Power button to forcefully shut down your Mac.
+
+5. Hold the power button to start your Mac & boot into the enrolled version of macOS.
+
+> a. **Apple-based Mac**: Hold Power button.\
+> b. **Intel-based Mac**: Hold <kbd>CMD</kbd> + <kbd>R</kbd> during boot.
+
+6. Navigate to https://www.github.com/assafdori/bypass-mdm
+
+7. Copy the script below:
+
+```zsh
+curl https://raw.githubusercontent.com/assafdori/bypass-mdm/main/bypass-mdm-dualboot.sh -o bypass-mdm-dualboot.sh && sudo chmod +x ./bypass-mdm-dualboot.sh && sudo ./bypass-mdm-dualboot.sh
+```
+
+8. Launch Terminal (Utilities > Terminal).
+
+9. Paste (<kbd>CMD</kbd> + <kbd>V</kbd>) and Run the script (<kbd>ENTER</kbd>).
+
+10. Input 1 for Autobypass.
+
+11. Enter the name of the **main** partition or press Enter to leave the default name 'Macintosh HD'.
+
+12. Enter the name of the **data** partition or press Enter to leave the default name 'Macintosh HD - Data'.
+
+13. Press Enter to leave the default username 'Apple'.
+
+14. Press Enter to leave the default  password '1234'.
+
+15. Wait for the script to finish & Reboot your Mac.
+
+16. Sign in with user (Apple) & password (1234)
+
+17. Skip all setup (Apple ID, Siri, Touch ID, Location Services)
+
+18. Once on the desktop navigate to System Settings > Users and Groups, and create your real Admin account.
+
+19. Log out of the Apple profile, and sign in into your real profile.
+
+20. Feel free set up properly now (Apple ID, Siri, Touch ID, Location Services).
+
+21. Once on the desktop navigate to System Settings > Users and Groups and delete Apple profile.
+
+22. Congratulations, you're MDM free! 💫
+
+### Final Notes
+*Although it's virtually impossible to catch that you've removed the MDM (because it wasn't even configured), be aware that the serial number of the laptop will still be shown in the inventory system of your company. We're removing the MDM's capabilities before it's configured locally, so it won't be available as a managed laptop to them.*
+
+**Use with caution.** <br>
+Probably a good idea to have a valid excuse as well. 🤫

--- a/bypass-mdm-dualboot.sh
+++ b/bypass-mdm-dualboot.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# Define color codes
+RED='\033[1;31m'
+GRN='\033[1;32m'
+BLU='\033[1;34m'
+YEL='\033[1;33m'
+PUR='\033[1;35m'
+CYAN='\033[1;36m'
+NC='\033[0m'
+
+# Display header
+echo -e "${CYAN}Bypass MDM By Assaf Dori (assafdori.com)${NC}"
+echo ""
+
+# Check if script is run as root
+if [[ $EUID -ne 0 ]]; then
+    echo -e "${RED}Error: This script must be run as root. Please use sudo.${RED}"
+    exit 1
+fi
+
+# Prompt user for choice
+PS3='Please enter your choice: '
+options=("Bypass MDM from Recovery" "Reboot & Exit")
+select opt in "${options[@]}"; do
+    case $opt in
+        "Bypass MDM from Recovery")
+            read -p "Enter the main partition (Default is 'Machintosh HD'): " baseVolume
+            baseVolume="${baseVolume:='Machintosh HD'}"
+            read -p "Enter the data partition (Default is 'Machintosh HD - Data'): " dataVolume
+            dataVolume="${dataVolume:='Machintosh HD - Data'}"
+
+            # Check if baseVolume exists
+            if [ ! -d "/Volumes/$baseVolume" ]; then
+                echo -e "${RED}Error: Main partition '/Volumes/$baseVolume' not found.${RED}"
+                exit 1
+            fi
+
+            # Check if dataVolume exists
+            if [ ! -d "/Volumes/$dataVolume" ]; then
+                echo -e "${RED}Error: Data partition '/Volumes/$dataVolume' not found.${RED}"
+                exit 1
+            fi
+
+            # Create Temporary User
+            echo -e "${NC}Create a Temporary User"
+            read -p "Enter Temporary Fullname (Default is 'Apple'): " realName
+            realName="${realName:=Apple}"
+            read -p "Enter Temporary Username (Default is 'Apple'): " username
+            username="${username:=Apple}"
+            read -p "Enter Temporary Password (Default is '1234'): " passw
+            passw="${passw:=1234}"
+
+            # Create User
+            dscl_path="/Volumes/${dataVolume}/private/var/db/dslocal/nodes/Default"
+            echo -e "${GREEN}Creating Temporary User"
+            dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username"
+            dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" UserShell "/bin/zsh"
+            dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" RealName "$realName"
+            dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" UniqueID "501"
+            dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" PrimaryGroupID "20"
+            mkdir "/Volumes/$dataVolume/Users/$username"
+            dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" NFSHomeDirectory "/Users/$username"
+            dscl -f "$dscl_path" localhost -passwd "/Local/Default/Users/$username" "$passw"
+            dscl -f "$dscl_path" localhost -append "/Local/Default/Groups/admin" GroupMembership $username
+
+            # Block MDM domains
+            echo "0.0.0.0 deviceenrollment.apple.com" >> "/Volumes/$baseVolume/etc/hosts"
+            echo "0.0.0.0 mdmenrollment.apple.com" >> "/Volumes/$baseVolume/etc/hosts"
+            echo "0.0.0.0 iprofiles.apple.com" >> "/Volumes/$baseVolume/etc/hosts"
+            echo -e "${GRN}Successfully blocked MDM & Profile Domains"
+
+            # Remove configuration profiles
+            touch "/Volumes/$dataVolume/private/var/db/.AppleSetupDone"
+            rm -rf "/Volumes/$baseVolume/db/ConfigurationProfiles/Settings/.cloudConfigHasActivationRecord"
+            rm -rf "/Volumes/$baseVolume/var/db/ConfigurationProfiles/Settings/.cloudConfigRecordFound"
+            touch "/Volumes/$baseVolume/var/db/ConfigurationProfiles/Settings/.cloudConfigProfileInstalled"
+            touch "/Volumes/$baseVolume/var/db/ConfigurationProfiles/Settings/.cloudConfigRecordNotFound"
+
+
+            echo -e "${GRN}MDM enrollment has been bypassed!${NC}"
+            echo -e "${NC}Exit terminal and reboot your Mac.${NC}"
+            break
+            ;;
+        "Reboot & Exit")
+            # Reboot & Exit
+            echo "Rebooting..."
+            reboot
+            break
+            ;;
+        *) echo "Invalid option $REPLY" ;;
+    esac
+done


### PR DESCRIPTION
### Summary

This update adds a new script and section to the documentation that explains how to **bypass MDM locally** when you already have access to an enrolled macOS installation **with sudo privileges**—enabling a **dual-boot setup** with a personal, unmanaged macOS installation.

---

### Use Case

Imagine you’ve received an MDM-enrolled Mac from your company. As a developer or technical user, you might have been granted **sudo privileges** to perform necessary tasks. However, you may want to:

- Keep the enrolled OS intact (for work or secure access to company resources),
- But also run a **personal macOS installation** free of MDM restrictions.

Dual-booting is the perfect solution in this scenario.

---

### Problem

When attempting to install a fresh copy of macOS on a new partition and boot into **Recovery Mode** for that new installation, macOS throws this error:

> **"There Are No Users on This Volume to Recover"**

As a result, you’re **unable to access recovery mode** on the fresh install and **cannot run the MDM bypass script** from there.

---

### Solution

This PR introduces a new script and documentation for the **new method**:  
Run the bypass script **directly from the enrolled OS**, using `sudo`, to modify the second, freshly installed macOS volume.

This was successfully tested on an **Macbook Pro with M4 Pro** running **macOS Sequoia 15.5**.

---

### Benefits

- Enables personal use of your device without compromising the company-managed environment.
- Provides a workaround when native recovery access is blocked by system limitations.
- Helps developers or tech users safely isolate work and personal environments.