### PR TITLE
Express script, v3 improvements, SSV fixes, dualboot fixes, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,40 @@
 
 A collection of scripts to bypass Mobile Device Management (MDM) enrollment during macOS setup.
 
-**Escolha seu script:**
+**Choose your script:**
 
-| Script | Melhor para | Executar de |
-|--------|-------------|-------------|
-| `bypass-mdm-express.sh` | **Recomendado.** Tudo em um. Backup + bypass + restore. | Recovery ou macOS normal |
-| `bypass-mdm-v3.sh` | Apple Silicon / macOS 11-26 | Recovery |
-| `bypass-mdm-v2.sh` | Casos simples, Intel | Recovery |
-| `bypass-mdm.sh` | Legado, nomes fixos | Recovery |
-| `bypass-mdm-dualboot.sh` | Dual-boot (gerenciado + pessoal) | macOS enrolado (sudo) |
+| Script | Best for | Run from |
+|--------|----------|----------|
+| `bypass-mdm-express.sh` | **Recommended.** All-in-one: backup + bypass + restore | Recovery |
+| `bypass-mdm-v3.sh` | Apple Silicon / macOS 11-26. SSV-aware. | Recovery |
+| `bypass-mdm-v2.sh` | Simple cases, Intel Macs | Recovery |
+| `bypass-mdm.sh` | Legacy, hardcoded volume names | Recovery |
+| `bypass-mdm-dualboot.sh` | Dual-boot (enrolled + personal macOS) | Enrolled OS (sudo) |
 
-### v3 — Apple Silicon / SSV-aware (Recommended)
+---
 
-The v3 script fixes the root cause of why v1/v2 fail on modern Macs: **System Volume sealing**. On Apple Silicon, macOS boots from a sealed, read-only snapshot. Writes to `/etc/hosts` or `/var/db/ConfigurationProfiles` on the System volume never reach the running OS. v3 writes everything to the **Data volume** (via `/private` firmlink) where the OS actually reads it.
+### Express — All-in-one (Recommended)
+
+Put this script on an external SSD, plug it into any Mac, run it from Recovery. No curl, no typing URLs, no downloads. Works entirely offline.
+
+**What it does:**
+1. Backs up your original state (hosts, config profiles, launchd config) to the SSD
+2. Suppresses MDM enrollment (blocks domains, resets markers, disables daemon)
+3. Can restore the original state later — take your Mac to Apple for re-enrollment, then restore
+
+```bash
+# Recovery mode -> Utilities -> Terminal
+chmod +x "/Volumes/YourSSDName/bypass-mdm-express.sh"
+"/Volumes/YourSSDName/bypass-mdm-express.sh"
+```
+
+The backup is stored on the SSD itself (`/.bypass-backup/`). To restore, re-run and pick "Restore original state".
+
+---
+
+### v3 — Apple Silicon / SSV-aware
+
+v3 fixes the root cause of why v1/v2 fail on modern Macs: **System Volume sealing**. On Apple Silicon, macOS boots from a sealed, read-only snapshot. Writes to `/etc/hosts` or `/var/db/ConfigurationProfiles` on the System volume never reach the running OS. v3 writes everything to the **Data volume** (via `/private` firmlink) where the OS actually reads it.
 
 **Additional improvements:**
 - Detects Data volume by APFS role (no hardcoded names)
@@ -31,13 +52,17 @@ The v3 script fixes the root cause of why v1/v2 fail on modern Macs: **System Vo
 curl -L https://raw.githubusercontent.com/assafdori/bypass-mdm/main/bypass-mdm-v3.sh -o bypass-mdm-v3.sh && chmod +x bypass-mdm-v3.sh && ./bypass-mdm-v3.sh
 ```
 
+---
+
 ### v2 — Automatic volume detection
 
-Improved version with dynamic volume detection. No need to know your volume name.
+Improved version with dynamic volume detection. No need to know your volume name. Now writes to Data volume paths (SSV-aware).
 
 ```bash
 curl -L https://raw.githubusercontent.com/assafdori/bypass-mdm/main/bypass-mdm-v2.sh -o bypass-mdm-v2.sh && chmod +x bypass-mdm-v2.sh && ./bypass-mdm-v2.sh
 ```
+
+---
 
 ### Original (legacy) — Hardcoded volumes
 
@@ -47,6 +72,8 @@ Original version with hardcoded "Macintosh HD" volume names.
 curl -L https://raw.githubusercontent.com/assafdori/bypass-mdm/main/bypass-mdm.sh -o bypass-mdm.sh && chmod +x ./bypass-mdm.sh && ./bypass-mdm.sh
 ```
 
+---
+
 ### Dual-boot setup
 
 If your Mac is enrolled by an organization but you have sudo access, you can create a separate partition with a fresh macOS install and bypass MDM on it:
@@ -55,30 +82,9 @@ If your Mac is enrolled by an organization but you have sudo access, you can cre
 curl -L https://raw.githubusercontent.com/assafdori/bypass-mdm/main/bypass-mdm-dualboot.sh -o bypass-mdm-dualboot.sh && sudo chmod +x bypass-mdm-dualboot.sh && sudo ./bypass-mdm-dualboot.sh
 ```
 
-Make sure the target volume names are correct — the script will ask for both the system and data volume names.
-
 ---
 
-### Express — Tudo em um (recomendado)
-
-O script **express** foi feito pra ser o mais simples possível:
-- Coloca num SSD externo, conecta em qualquer Mac, executa
-- Faz **backup automático** do estado original antes de qualquer modificação
-- **Restaura** tudo se precisar (leva na Apple, eles re-matriculam)
-- Detecta se está no Recovery ou no macOS normal e age conforme o possível
-- Nunca deleta seus dados
-
-```bash
-# 1. Copie o script pro seu SSD externo
-# 2. Conecte o SSD no Mac
-# 3. Abra o Terminal e:
-chmod +x /Volumes/SEU_SSD/bypass-mdm-express.sh
-sudo /Volumes/SEU_SSD/bypass-mdm-express.sh
-```
-
-O backup fica no próprio SSD (`/.bypass-backup`). Pra restaurar é só rodar de novo e escolher "Restore".
-
-### v3 — Apple Silicon / SSV-aware
+### Instructions (Recovery mode)
 
 1. Long press Power to shut down.
 2. Boot into Recovery:
@@ -86,8 +92,10 @@ O backup fica no próprio SSD (`/.bypass-backup`). Pra restaurar é só rodar de
    - **Intel**: Hold CMD + R during boot.
 3. Connect to WiFi.
 4. Open Terminal (Utilities > Terminal).
-5. Run the script (see above).
+5. Run the script.
 6. Reboot when done.
+
+---
 
 ### Legal
 

--- a/README.md
+++ b/README.md
@@ -1,61 +1,76 @@
-# Bypass-MDM for MacOS 26 Tahoe💻
+# Bypass-MDM for macOS
 
 ![mdm-screen](https://raw.githubusercontent.com/assafdori/bypass-mdm/main/mdm-screen.png)
 
-#### Prerequisites ⚠️
+A collection of scripts to bypass Mobile Device Management (MDM) enrollment during macOS setup.
 
-- **It is advised to erase the hard-drive prior to starting.**
-- **It is advised to re-install MacOS using an external flash drive.**
-- **Device language needs to be set to English, it can be changed afterwards.**
+**Choose your script:**
 
+| Script | Best for | Run from |
+|--------|----------|----------|
+| `bypass-mdm-v3.sh` | Apple Silicon / macOS 11-26. **Recommended.** | Recovery |
+| `bypass-mdm-v2.sh` | Simple cases, Intel Macs | Recovery |
+| `bypass-mdm.sh` | Legacy, hardcoded volume names | Recovery |
+| `bypass-mdm-dualboot.sh` | Dual-boot (enrolled + personal macOS) | Enrolled OS (sudo) |
 
-#### Follow steps below to bypass MDM setup during a fresh installation of MacOS
+### v3 — Apple Silicon / SSV-aware (Recommended)
 
-> Upon arriving to the setup stage of forced MDM enrollement:
+The v3 script fixes the root cause of why v1/v2 fail on modern Macs: **System Volume sealing**. On Apple Silicon, macOS boots from a sealed, read-only snapshot. Writes to `/etc/hosts` or `/var/db/ConfigurationProfiles` on the System volume never reach the running OS. v3 writes everything to the **Data volume** (via `/private` firmlink) where the OS actually reads it.
 
-1. Long press Power button to forcefully shut down your Mac.
+**Additional improvements:**
+- Detects Data volume by APFS role (no hardcoded names)
+- Supports FileVault-encrypted volumes (unlocks automatically)
+- Reads the org MDM host from the activation record and blocks it
+- Disables the enrollment daemon via launchd override on the Data volume
+- Two modes: suppress-only (no user created) or full bypass
+- Leaves `gdmf.apple.com` and `albert.apple.com` unblocked (Software Update, iMessage)
 
-2. Hold the power button to start your Mac & boot into recovery mode.
-
-> a. **Apple-based Mac**: Hold Power button.\
-> b. **Intel-based Mac**: Hold <kbd>CMD</kbd> + <kbd>R</kbd> during boot.
-
-3. Connect to WiFi to activate your Mac.
-
-4. Enter Recovery Mode & Open Safari.
-
-5. Navigate to https://www.github.com/assafdori/bypass-mdm
-
-6. Copy the script below:
-
-```zsh
-curl https://raw.githubusercontent.com/assafdori/bypass-mdm/main/bypass-mdm.sh -o bypass-mdm.sh && chmod +x ./bypass-mdm.sh && ./bypass-mdm.sh
+```bash
+# Run in Recovery mode (Utilities > Terminal)
+curl -L https://raw.githubusercontent.com/assafdori/bypass-mdm/main/bypass-mdm-v3.sh -o bypass-mdm-v3.sh && chmod +x bypass-mdm-v3.sh && ./bypass-mdm-v3.sh
 ```
 
-7. Launch Terminal (Utilities > Terminal).
+### v2 — Automatic volume detection
 
-8. Paste (<kbd>CMD</kbd> + <kbd>V</kbd>) and Run the script (<kbd>ENTER</kbd>).
+Improved version with dynamic volume detection. No need to know your volume name.
 
-9. Input 1 for Autobypass.
+```bash
+curl -L https://raw.githubusercontent.com/assafdori/bypass-mdm/main/bypass-mdm-v2.sh -o bypass-mdm-v2.sh && chmod +x bypass-mdm-v2.sh && ./bypass-mdm-v2.sh
+```
 
-10. Press Enter to leave the default username 'Apple'.
+### Original (legacy) — Hardcoded volumes
 
-11. Press Enter to leave the default  password '1234'.
+Original version with hardcoded "Macintosh HD" volume names.
 
-12. Wait for the script to finish & Reboot your Mac.
+```bash
+curl -L https://raw.githubusercontent.com/assafdori/bypass-mdm/main/bypass-mdm.sh -o bypass-mdm.sh && chmod +x ./bypass-mdm.sh && ./bypass-mdm.sh
+```
 
-13. Sign in with user (Apple) & password (1234)
+### Dual-boot setup
 
-14. Skip all setup (Apple ID, Siri, Touch ID, Location Services)
+If your Mac is enrolled by an organization but you have sudo access, you can create a separate partition with a fresh macOS install and bypass MDM on it:
 
-15. Once on the desktop navigate to System Settings > Users and Groups, and create your real Admin account.
+```bash
+curl -L https://raw.githubusercontent.com/assafdori/bypass-mdm/main/bypass-mdm-dualboot.sh -o bypass-mdm-dualboot.sh && sudo chmod +x bypass-mdm-dualboot.sh && sudo ./bypass-mdm-dualboot.sh
+```
 
-16. Log out of the Apple profile, and sign in into your real profile.
+Make sure the target volume names are correct — the script will ask for both the system and data volume names.
 
-17. Feel free set up properly now (Apple ID, Siri, Touch ID, Location Services).
+---
 
-18. Once on the desktop navigate to System Settings > Users and Groups and delete Apple profile.
+### Instructions (Recovery mode)
 
-19. Congratulations, you're MDM free! 💫
+1. Long press Power to shut down.
+2. Boot into Recovery:
+   - **Apple Silicon**: Hold Power until "Loading startup options" appears, then Options > Continue.
+   - **Intel**: Hold CMD + R during boot.
+3. Connect to WiFi.
+4. Open Terminal (Utilities > Terminal).
+5. Run the script (see above).
+6. Reboot when done.
 
-###### Although it's virtually impossible to catch that you've removed the MDM (because it wasn't even configured), be aware that the serial number of the laptop will still be shown in the inventory system of your company. We're removing the MDM's capabilities before it's configured locally, so it won't be available as a managed laptop to them. Use with caution. Probably a good idea to have a valid excuse as well.
+### Legal
+
+This only suppresses MDM locally. Your serial stays in the org's Apple Business Manager. The permanent fix is them releasing it.
+
+Use on devices you own. I'm not responsible for what you do with this.

--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@
 
 A collection of scripts to bypass Mobile Device Management (MDM) enrollment during macOS setup.
 
-**Choose your script:**
+**Escolha seu script:**
 
-| Script | Best for | Run from |
-|--------|----------|----------|
-| `bypass-mdm-v3.sh` | Apple Silicon / macOS 11-26. **Recommended.** | Recovery |
-| `bypass-mdm-v2.sh` | Simple cases, Intel Macs | Recovery |
-| `bypass-mdm.sh` | Legacy, hardcoded volume names | Recovery |
-| `bypass-mdm-dualboot.sh` | Dual-boot (enrolled + personal macOS) | Enrolled OS (sudo) |
+| Script | Melhor para | Executar de |
+|--------|-------------|-------------|
+| `bypass-mdm-express.sh` | **Recomendado.** Tudo em um. Backup + bypass + restore. | Recovery ou macOS normal |
+| `bypass-mdm-v3.sh` | Apple Silicon / macOS 11-26 | Recovery |
+| `bypass-mdm-v2.sh` | Casos simples, Intel | Recovery |
+| `bypass-mdm.sh` | Legado, nomes fixos | Recovery |
+| `bypass-mdm-dualboot.sh` | Dual-boot (gerenciado + pessoal) | macOS enrolado (sudo) |
 
 ### v3 — Apple Silicon / SSV-aware (Recommended)
 
@@ -58,7 +59,26 @@ Make sure the target volume names are correct — the script will ask for both t
 
 ---
 
-### Instructions (Recovery mode)
+### Express — Tudo em um (recomendado)
+
+O script **express** foi feito pra ser o mais simples possível:
+- Coloca num SSD externo, conecta em qualquer Mac, executa
+- Faz **backup automático** do estado original antes de qualquer modificação
+- **Restaura** tudo se precisar (leva na Apple, eles re-matriculam)
+- Detecta se está no Recovery ou no macOS normal e age conforme o possível
+- Nunca deleta seus dados
+
+```bash
+# 1. Copie o script pro seu SSD externo
+# 2. Conecte o SSD no Mac
+# 3. Abra o Terminal e:
+chmod +x /Volumes/SEU_SSD/bypass-mdm-express.sh
+sudo /Volumes/SEU_SSD/bypass-mdm-express.sh
+```
+
+O backup fica no próprio SSD (`/.bypass-backup`). Pra restaurar é só rodar de novo e escolher "Restore".
+
+### v3 — Apple Silicon / SSV-aware
 
 1. Long press Power to shut down.
 2. Boot into Recovery:

--- a/bypass-mdm-dualboot.sh
+++ b/bypass-mdm-dualboot.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+set -euo pipefail
+
+# bypass-mdm-dualboot.sh -- MDM bypass for dual-boot setups.
+# Run this script from an enrolled macOS (with sudo) targeting a second,
+# freshly-installed macOS volume to bypass MDM enrollment.
+#
+# Unlike the Recovery-mode scripts, this script writes to the *Data* volume
+# of the target installation (via /private firmlink), which is the correct
+# location on Apple Silicon with Signed System Volume (SSV).
+#
+# Usage: sudo ./bypass-mdm-dualboot.sh
+
+RED='\033[1;31m'; GRN='\033[1;32m'; BLU='\033[1;34m'; YEL='\033[1;33m'; CYAN='\033[1;36m'; NC='\033[0m'
+
+error_exit() { echo -e "${RED}ERROR: $1${NC}" >&2; exit 1; }
+warn()       { echo -e "${YEL}WARNING: $1${NC}" >&2; }
+success()    { echo -e "${GRN}\u2713 $1${NC}"; }
+info()       { echo -e "${BLU}\u2139 $1${NC}"; }
+
+if [[ $EUID -ne 0 ]]; then
+	error_exit "This script must be run as root. Use: sudo $0"
+fi
+
+echo ""
+echo -e "${CYAN}Bypass MDM -- Dual-Boot Mode${NC}"
+echo ""
+
+PS3='Please enter your choice: '
+options=("Bypass MDM on target volume" "Reboot & Exit")
+select opt in "${options[@]}"; do
+	case $opt in
+	"Bypass MDM on target volume")
+
+		read -p "Enter the target system volume name (default 'Macintosh HD'): " baseVolume
+		baseVolume="${baseVolume:=Macintosh HD}"
+		read -p "Enter the target data volume name (default 'Macintosh HD - Data'): " dataVolume
+		dataVolume="${dataVolume:=Macintosh HD - Data}"
+
+		sys_path="/Volumes/$baseVolume"
+		data_path="/Volumes/$dataVolume"
+
+		if [ ! -d "$sys_path" ]; then
+			error_exit "System volume not found at: $sys_path"
+		fi
+		if [ ! -d "$data_path" ]; then
+			error_exit "Data volume not found at: $data_path"
+		fi
+
+		info "Target system volume: $sys_path"
+		info "Target data volume: $data_path"
+
+		# Create Temporary User on the Data volume
+		echo -e "${NC}Create a Temporary Admin User${NC}"
+		read -p "Enter Temporary Fullname (Default is 'Apple'): " realName
+		realName="${realName:=Apple}"
+		read -p "Enter Temporary Username (Default is 'Apple'): " username
+		username="${username:=Apple}"
+		read -p "Enter Temporary Password (Default is '1234'): " passw
+		passw="${passw:=1234}"
+
+		dscl_path="$data_path/private/var/db/dslocal/nodes/Default"
+		if [ ! -d "$dscl_path" ]; then
+			error_exit "Directory Services path not found: $dscl_path"
+		fi
+
+		info "Creating user account: $username"
+		dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username"
+		dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" UserShell "/bin/zsh"
+		dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" RealName "$realName"
+		dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" UniqueID "501"
+		dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" PrimaryGroupID "20"
+		mkdir -p "$data_path/Users/$username"
+		dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" NFSHomeDirectory "/Users/$username"
+		dscl -f "$dscl_path" localhost -passwd "/Local/Default/Users/$username" "$passw"
+		dscl -f "$dscl_path" localhost -append "/Local/Default/Groups/admin" GroupMembership "$username"
+		success "Admin account created"
+
+		# Block MDM domains on the DATA volume's hosts file (SSV-aware)
+		hosts_file="$data_path/private/etc/hosts"
+		[ -f "$hosts_file" ] || touch "$hosts_file"
+		echo "0.0.0.0 deviceenrollment.apple.com" >>"$hosts_file"
+		echo "0.0.0.0 mdmenrollment.apple.com"    >>"$hosts_file"
+		echo "0.0.0.0 iprofiles.apple.com"        >>"$hosts_file"
+		success "MDM domains blocked"
+
+		# Mark setup as done
+		touch "$data_path/private/var/db/.AppleSetupDone"
+		success "Setup Assistant will be skipped"
+
+		# Remove configuration profiles on the DATA volume
+		config_path="$data_path/private/var/db/ConfigurationProfiles/Settings"
+		mkdir -p "$config_path"
+		rm -f "$config_path/.cloudConfigHasActivationRecord" \
+		      "$config_path/.cloudConfigRecordFound"
+		touch "$config_path/.cloudConfigProfileInstalled" \
+		      "$config_path/.cloudConfigRecordNotFound"
+		success "Configuration profiles reset"
+
+		echo ""
+		echo -e "${GRN}MDM bypass applied to target volume!${NC}"
+		echo -e "${NC}Reboot into the new installation and login with:${NC}"
+		echo -e "${YEL}  User: $username${NC}"
+		echo -e "${YEL}  Pass: $passw${NC}"
+		echo ""
+		break
+		;;
+	"Reboot & Exit")
+		info "Rebooting..."
+		reboot
+		break
+		;;
+	*) echo -e "${RED}Invalid option $REPLY${NC}" ;;
+	esac
+done

--- a/bypass-mdm-express.sh
+++ b/bypass-mdm-express.sh
@@ -1,0 +1,328 @@
+#!/bin/bash
+set -euo pipefail
+
+# bypass-mdm-express.sh — All-in-one MDM tool.
+# Put this on an external SSD. Plug. Run. Done.
+#
+# Three modes:
+#   1. Backup + Bypass — saves current state, removes MDM
+#   2. Restore — reverts to pre-bypass state  
+#   3. Check status — see if MDM is active
+#
+# Works from Recovery (full bypass) or normal boot (sudo only, partial bypass).
+# Always reversible. Never deletes your data.
+
+RED='\033[1;31m'; GRN='\033[1;32m'; BLU='\033[1;34m'; YEL='\033[1;33m'; CYAN='\033[1;36m'; NC='\033[0m'
+error_exit() { echo -e "${RED}ERRO: $1${NC}" >&2; exit 1; }
+warn()       { echo -e "${YEL}AVISO: $1${NC}" >&2; }
+success()    { echo -e "${GRN}OK $1${NC}"; }
+info()       { echo -e "${BLU}  $1${NC}"; }
+step()       { echo -e "${CYAN}> $1${NC}"; }
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BACKUP_DIR="$SCRIPT_DIR/.bypass-backup"
+
+detect_environment() {
+	if [ -d "/Volumes/Macintosh HD" ] || [ -d "/Volumes/MacOS" ] || [ -d "/System/Installation" ]; then
+		echo "recovery"
+	elif [ "$(csrutil status 2>/dev/null | grep -c 'enabled')" -eq 1 ]; then
+		echo "normal_sip_on"  
+	else
+		echo "normal_sip_off"
+	fi
+}
+
+find_data_volume() {
+	local vol=""
+	for v in /Volumes/*; do
+		[ -d "$v/private/var/db/dslocal/nodes/Default" ] && vol="$v" && break
+	done
+	if [ -z "$vol" ] && [ -d "/Volumes/Data" ]; then
+		vol="/Volumes/Data"
+	fi
+	echo "$vol"
+}
+
+find_system_volume() {
+	local data_vol="$1"
+	[ -z "$data_vol" ] && return 1
+	for v in /Volumes/*; do
+		[ "$v" != "$data_vol" ] && [ -d "$v/System" ] && [ ! -d "$v/private/var/db/dslocal" ] && echo "$v" && return 0
+	done
+	echo ""
+}
+
+get_hosts_path() {
+	local env="$1" data_vol="$2" sys_vol="$3"
+	if [ "$env" = "recovery" ] && [ -n "$data_vol" ]; then
+		echo "$data_vol/private/etc/hosts"
+	elif [ "$env" = "recovery" ] && [ -n "$sys_vol" ]; then
+		echo "$sys_vol/etc/hosts"
+	else
+		echo "/etc/hosts"
+	fi
+}
+
+get_cfg_path() {
+	local env="$1" data_vol="$2" sys_vol="$3"
+	if [ "$env" = "recovery" ] && [ -n "$data_vol" ]; then
+		echo "$data_vol/private/var/db/ConfigurationProfiles/Settings"
+	elif [ "$env" = "recovery" ] && [ -n "$sys_vol" ]; then
+		echo "$sys_vol/var/db/ConfigurationProfiles/Settings"
+	else
+		echo ""
+	fi
+}
+
+backup_state() {
+	local env="$1" data_vol="$2" sys_vol="$3"
+	mkdir -p "$BACKUP_DIR"
+	step "Salvando backup em $BACKUP_DIR"
+
+	local hosts_path
+	hosts_path=$(get_hosts_path "$env" "$data_vol" "$sys_vol")
+	local cfg_path
+	cfg_path=$(get_cfg_path "$env" "$data_vol" "$sys_vol")
+
+	if [ -f "$hosts_path" ]; then
+		cp "$hosts_path" "$BACKUP_DIR/hosts.backup"
+		success "hosts salvo"
+	fi
+	if [ -d "$cfg_path" ]; then
+		mkdir -p "$BACKUP_DIR/ConfigurationProfiles"
+		cp -r "$cfg_path"/* "$BACKUP_DIR/ConfigurationProfiles/" 2>/dev/null || true
+		success "config profiles salvos"
+	fi
+	date +%Y-%m-%d_%H-%M-%S > "$BACKUP_DIR/timestamp"
+	success "Backup concluido em $(cat "$BACKUP_DIR/timestamp")"
+}
+
+restore_state() {
+	local env="$1" data_vol="$2" sys_vol="$3"
+	
+	if [ ! -f "$BACKUP_DIR/timestamp" ]; then
+		error_exit "Nenhum backup encontrado em $BACKUP_DIR"
+	fi
+
+	step "Restaurando backup de $(cat "$BACKUP_DIR/timestamp")"
+
+	local hosts_path
+	hosts_path=$(get_hosts_path "$env" "$data_vol" "$sys_vol")
+	local cfg_path
+	cfg_path=$(get_cfg_path "$env" "$data_vol" "$sys_vol")
+
+	if [ -f "$BACKUP_DIR/hosts.backup" ] && [ -f "$hosts_path" ]; then
+		sed -i '' '/# Added by bypass/d' "$hosts_path" 2>/dev/null || true
+		cp "$BACKUP_DIR/hosts.backup" "$hosts_path"
+		success "hosts restaurado"
+	fi
+	if [ -d "$BACKUP_DIR/ConfigurationProfiles" ] && [ -n "$cfg_path" ]; then
+		mkdir -p "$cfg_path"
+		cp -r "$BACKUP_DIR/ConfigurationProfiles"/* "$cfg_path/" 2>/dev/null || true
+		success "config profiles restaurados"
+	fi
+
+	# Re-enable daemon
+	if [ "$env" != "recovery" ]; then
+		sudo launchctl enable system/com.apple.ManagedClient.enroll 2>/dev/null || true
+		sudo launchctl enable system/com.apple.mdmclient.daemon.runatboot 2>/dev/null || true
+		success "daemons reativados"
+	fi
+
+	rm -f "$BACKUP_DIR/timestamp"
+	success "Restauro concluido"
+}
+
+block_hosts() {
+	local hosts_path="$1"
+	[ ! -f "$hosts_path" ] && touch "$hosts_path"
+
+	grep -q "Added by bypass-mdm" "$hosts_path" 2>/dev/null || {
+		echo "" >>"$hosts_path"
+		echo "# Added by bypass-mdm — DEP enrollment block" >>"$hosts_path"
+	}
+
+	local domains=(
+		iprofiles.apple.com
+		deviceenrollment.apple.com
+		mdmenrollment.apple.com
+		acmdm.apple.com
+	)
+	local d
+	for d in "${domains[@]}"; do
+		grep -qiE "[[:space:]]$d(\$|[[:space:]])" "$hosts_path" 2>/dev/null && continue
+		printf '0.0.0.0 %s\n::      %s\n' "$d" "$d" >>"$hosts_path"
+		success "bloqueado $d"
+	done
+}
+
+reset_markers() {
+	local cfg_path="$1"
+	[ -z "$cfg_path" ] && return 1
+	mkdir -p "$cfg_path"
+	rm -f "$cfg_path/.cloudConfigHasActivationRecord" \
+	      "$cfg_path/.cloudConfigRecordFound" \
+	      "$cfg_path/.cloudConfigTimerCheck" \
+	      "$cfg_path/com.apple.mdm.depnag.plist" \
+	      "$cfg_path/com.apple.mdm.prelogin.plist" 2>/dev/null
+	touch "$cfg_path/.cloudConfigRecordNotFound" \
+	      "$cfg_path/.cloudConfigProfileInstalled"
+	success "marcadores resetados"
+}
+
+disable_daemon_launchctl() {
+	sudo launchctl disable system/com.apple.ManagedClient.enroll 2>/dev/null || true
+	sudo launchctl disable system/com.apple.mdmclient.daemon.runatboot 2>/dev/null || true
+	success "daemon desativado (launchctl)"
+}
+
+disable_daemon_plist() {
+	local data_vol="$1"
+	[ -z "$data_vol" ] && return 1
+	local plist="$data_vol/private/var/db/com.apple.xpc.launchd/disabled.plist"
+	mkdir -p "$(dirname "$plist")"
+	[ -f "$plist" ] || printf '<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0"><dict/></plist>\n' >"$plist"
+	for label in com.apple.ManagedClient.enroll com.apple.mdmclient.daemon.runatboot; do
+		/usr/libexec/PlistBuddy -c "Add :$label bool true" "$plist" 2>/dev/null \
+			|| /usr/libexec/PlistBuddy -c "Set :$label true" "$plist" 2>/dev/null
+	done
+	success "daemon desativado (plist override)"
+}
+
+create_user_recovery() {
+	local data_vol="$1"
+	[ -z "$data_vol" ] && error_exit "Volume de dados nao encontrado"
+
+	local dscl_path="$data_vol/private/var/db/dslocal/nodes/Default"
+	[ ! -d "$dscl_path" ] && error_exit "Diretorio de usuarios nao encontrado em $dscl_path"
+
+	read -p "Nome completo (padrao 'Apple'): " realName; realName="${realName:=Apple}"
+	read -p "Nome de usuario (padrao 'Apple'): " username; username="${username:=Apple}"
+	read -p "Senha (padrao '1234'): " passw; passw="${passw:=1234}"
+
+	step "Criando usuario $username"
+	dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" 2>/dev/null || true
+	dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" UserShell "/bin/zsh" 2>/dev/null
+	dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" RealName "$realName" 2>/dev/null
+	dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" UniqueID "501" 2>/dev/null
+	dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" PrimaryGroupID "20" 2>/dev/null
+	dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" NFSHomeDirectory "/Users/$username" 2>/dev/null
+	dscl -f "$dscl_path" localhost -passwd  "/Local/Default/Users/$username" "$passw" 2>/dev/null || warn "Falha ao definir senha"
+	dscl -f "$dscl_path" localhost -append  "/Local/Default/Groups/admin" GroupMembership "$username" 2>/dev/null || true
+	mkdir -p "$data_vol/Users/$username"
+	touch "$data_vol/private/var/db/.AppleSetupDone"
+	success "Usuario $username criado. Login: $username / $passw"
+}
+
+# ============================================================
+# MAIN
+# ============================================================
+env=$(detect_environment)
+data_vol=$(find_data_volume)
+sys_vol=""
+[ -n "$data_vol" ] && sys_vol=$(find_system_volume "$data_vol")
+
+echo ""
+echo -e "${CYAN}============================================${NC}"
+echo -e "${CYAN}   Bypass MDM Express                      ${NC}"
+echo -e "${CYAN}============================================${NC}"
+echo ""
+echo -e "${BLU}Modo detectado:${NC} $env"
+[ -n "$data_vol" ] && echo -e "${BLU}Volume dados:${NC} $data_vol"
+[ -n "$sys_vol" ]  && echo -e "${BLU}Volume sistema:${NC} $sys_vol"
+echo ""
+
+PS3="Escolha uma opcao: "
+options=(
+	"Backup + Bypass MDM (recomendado)"
+	"Restore (voltar ao estado original)"
+	"Checar status do MDM"
+	"Sair"
+)
+select opt in "${options[@]}"; do
+	case $opt in
+	"Backup + Bypass MDM (recomendado)")
+		echo ""
+
+		backup_state "$env" "$data_vol" "$sys_vol"
+		echo ""
+
+		hosts_path=$(get_hosts_path "$env" "$data_vol" "$sys_vol")
+		cfg_path=$(get_cfg_path "$env" "$data_vol" "$sys_vol")
+
+		if [ "$env" = "recovery" ]; then
+			step "Modo Recovery — bypass completo"
+			block_hosts "$hosts_path"
+			reset_markers "$cfg_path"
+			disable_daemon_plist "$data_vol" "$sys_vol"
+
+			echo ""
+			echo -e "${YEL}Criar usuario admin temporario?${NC}"
+			read -p "Se for setup novo (tela de enrolamento), digite 's' [s/N]: " create_user
+			if [[ "$create_user" =~ ^[Ss]$ ]]; then
+				create_user_recovery "$data_vol"
+			fi
+		else
+			step "Modo normal — bypass parcial (SIP $([ "$env" = "normal_sip_on" ] && echo "ATIVADO" || echo "DESATIVADO"))"
+			[ "$env" = "normal_sip_off" ] && warn "SIP desativado: escrita extra disponivel" || warn "SIP ativado: apenas bloqueio de dominios e launchctl"
+			
+			if [ -w "$hosts_path" ] || [ "$EUID" -eq 0 ]; then
+				block_hosts "$hosts_path"
+			else
+				warn "Sem permissao para escrever em $hosts_path (tente com sudo)"
+			fi
+
+			if [ "$env" != "normal_sip_on" ] && [ -n "$cfg_path" ]; then
+				reset_markers "$cfg_path"
+			fi
+
+			disable_daemon_launchctl
+		fi
+
+		echo ""
+		echo -e "${GRN}============================================${NC}"
+		echo -e "${GRN}  Pronto! Backup salvo em $BACKUP_DIR        ${NC}"
+		echo -e "${GRN}  Para restaurar: rode este script denovo   ${NC}"
+		echo -e "${GRN}  e escolha 'Restore'                       ${NC}"
+		echo -e "${GRN}============================================${NC}"
+		break
+		;;
+
+	"Restore (voltar ao estado original)")
+		echo ""
+		restore_state "$env" "$data_vol" "$sys_vol"
+		echo -e "${GRN}Estado original restaurado.${NC}"
+		break
+		;;
+
+	"Checar status do MDM")
+		echo ""
+		step "Checando enrolamento DEP..."
+		if command -v profiles &>/dev/null; then
+			profiles status -type enrollment 2>/dev/null || warn "nao foi possivel checar"
+		else
+			warn "comando 'profiles' nao disponivel (rode do Recovery ou macOS normal)"
+		fi
+
+		step "Hosts bloqueados:"
+		hosts_path=$(get_hosts_path "$env" "$data_vol" "$sys_vol")
+		if [ -f "$hosts_path" ]; then
+			grep -iE 'iprofiles|enrollment|mdm|acmdm' "$hosts_path" 2>/dev/null || echo "  (nenhum)"
+		fi
+
+		step "Backup existente:"
+		if [ -f "$BACKUP_DIR/timestamp" ]; then
+			echo "  $(cat "$BACKUP_DIR/timestamp")"
+		else
+			echo "  (nenhum)"
+		fi
+		echo ""
+		break
+		;;
+
+	"Sair")
+		exit 0
+		;;
+	*) echo -e "${RED}Opcao invalida $REPLY${NC}" ;;
+	esac
+done

--- a/bypass-mdm-express.sh
+++ b/bypass-mdm-express.sh
@@ -2,327 +2,318 @@
 set -euo pipefail
 
 # bypass-mdm-express.sh — All-in-one MDM tool.
-# Put this on an external SSD. Plug. Run. Done.
+# Put this on an external SSD. Plug into any Mac. Run from Recovery.
 #
-# Three modes:
-#   1. Backup + Bypass — saves current state, removes MDM
-#   2. Restore — reverts to pre-bypass state  
-#   3. Check status — see if MDM is active
+# What it does:
+#   1. Backs up the current state (hosts, config profiles)
+#   2. Suppresses MDM enrollment
+#   3. Can restore the original state later
 #
-# Works from Recovery (full bypass) or normal boot (sudo only, partial bypass).
-# Always reversible. Never deletes your data.
+# Why "express": no curl, no download, no typing URLs.
+# Just chmod +x and run. Backup stays on the SSD so you can
+# restore whenever you want — take it to Apple, let them
+# re-enroll, then restore if needed.
+#
+# RUN FROM RECOVERY (Apple Silicon: hold Power -> Options ->
+# Utilities -> Terminal). Use responsibly.
 
 RED='\033[1;31m'; GRN='\033[1;32m'; BLU='\033[1;34m'; YEL='\033[1;33m'; CYAN='\033[1;36m'; NC='\033[0m'
-error_exit() { echo -e "${RED}ERRO: $1${NC}" >&2; exit 1; }
-warn()       { echo -e "${YEL}AVISO: $1${NC}" >&2; }
-success()    { echo -e "${GRN}OK $1${NC}"; }
-info()       { echo -e "${BLU}  $1${NC}"; }
-step()       { echo -e "${CYAN}> $1${NC}"; }
+error_exit() { echo -e "${RED}ERROR: $1${NC}" >&2; exit 1; }
+warn()       { echo -e "${YEL}WARNING: $1${NC}" >&2; }
+success()    { echo -e "${GRN}\u2713 $1${NC}"; }
+info()       { echo -e "${BLU}\u2139 $1${NC}"; }
+step()       { echo -e "${CYAN}\u25b8 $1${NC}"; }
+
+PB=/usr/libexec/PlistBuddy
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BACKUP_DIR="$SCRIPT_DIR/.bypass-backup"
 
-detect_environment() {
-	if [ -d "/Volumes/Macintosh HD" ] || [ -d "/Volumes/MacOS" ] || [ -d "/System/Installation" ]; then
-		echo "recovery"
-	elif [ "$(csrutil status 2>/dev/null | grep -c 'enabled')" -eq 1 ]; then
-		echo "normal_sip_on"  
-	else
-		echo "normal_sip_off"
+# ------------------------------------------------------------------
+# Detect and mount the Data volume
+# ------------------------------------------------------------------
+resolve_data_volume() {
+	step "Locating the Data volume by APFS role..."
+
+	local id mount_pt
+
+	id=$(diskutil apfs list 2>/dev/null \
+		| awk '/\(Data\)/ && match($0, /disk[0-9]+s[0-9]+/) {print substr($0, RSTART, RLENGTH); exit}')
+
+	if [ -z "$id" ] || ! diskutil info "/dev/$id" >/dev/null 2>&1; then
+		id=$(diskutil list 2>/dev/null \
+			| awk '/[[:space:]]Data[[:space:]]/{for(i=1;i<=NF;i++) if($i ~ /^disk[0-9]+s[0-9]+$/) v=$i} END{print v}')
 	fi
-}
 
-find_data_volume() {
-	local vol=""
-	for v in /Volumes/*; do
-		[ -d "$v/private/var/db/dslocal/nodes/Default" ] && vol="$v" && break
-	done
-	if [ -z "$vol" ] && [ -d "/Volumes/Data" ]; then
-		vol="/Volumes/Data"
-	fi
-	echo "$vol"
-}
-
-find_system_volume() {
-	local data_vol="$1"
-	[ -z "$data_vol" ] && return 1
-	for v in /Volumes/*; do
-		[ "$v" != "$data_vol" ] && [ -d "$v/System" ] && [ ! -d "$v/private/var/db/dslocal" ] && echo "$v" && return 0
-	done
-	echo ""
-}
-
-get_hosts_path() {
-	local env="$1" data_vol="$2" sys_vol="$3"
-	if [ "$env" = "recovery" ] && [ -n "$data_vol" ]; then
-		echo "$data_vol/private/etc/hosts"
-	elif [ "$env" = "recovery" ] && [ -n "$sys_vol" ]; then
-		echo "$sys_vol/etc/hosts"
-	else
-		echo "/etc/hosts"
-	fi
-}
-
-get_cfg_path() {
-	local env="$1" data_vol="$2" sys_vol="$3"
-	if [ "$env" = "recovery" ] && [ -n "$data_vol" ]; then
-		echo "$data_vol/private/var/db/ConfigurationProfiles/Settings"
-	elif [ "$env" = "recovery" ] && [ -n "$sys_vol" ]; then
-		echo "$sys_vol/var/db/ConfigurationProfiles/Settings"
-	else
+	if [ -z "$id" ] || ! diskutil info "/dev/$id" >/dev/null 2>&1; then
+		warn "Could not auto-detect the Data volume."
+		diskutil list >&2
 		echo ""
+		read -p "Type the Data volume identifier (e.g. disk3s1): " id </dev/tty
+		id="${id#/dev/}"
 	fi
+
+	[ -n "$id" ] || error_exit "No Data volume identifier provided."
+	local data_dev="/dev/$id"
+	diskutil info "$data_dev" >/dev/null 2>&1 || error_exit "Not a valid disk: $data_dev"
+	info "Data volume device: $data_dev"
+
+	_mount_point() { diskutil info "$data_dev" 2>/dev/null | awk -F': *' '/Mount Point/{print $2}' | sed 's/[[:space:]]*$//'; }
+
+	mount_pt=$(_mount_point)
+
+	if [ -z "$mount_pt" ] || [ ! -d "$mount_pt" ]; then
+		info "Data volume not mounted — mounting..."
+		diskutil mount "$data_dev" 2>/dev/null || true
+		mount_pt=$(_mount_point)
+	fi
+
+	if [ -z "$mount_pt" ] || [ ! -d "$mount_pt" ]; then
+		warn "Data volume is FileVault-locked — need to unlock."
+		echo -e "${YEL}Enter the password of an account on this Mac (or FileVault recovery key):${NC}" >&2
+		diskutil apfs unlockVolume "$data_dev" 2>/dev/null \
+			|| error_exit "Failed to unlock Data volume."
+		mount_pt=$(_mount_point)
+	fi
+
+	[ -d "$mount_pt" ] || error_exit "Data volume mount point not found."
+	[ -d "$mount_pt/private/var/db/dslocal/nodes/Default" ] \
+		|| error_exit "This does not look like a macOS Data volume (no dslocal node)."
+
+	success "Data volume mounted at: $mount_pt"
+	echo "$mount_pt"
 }
 
+# ------------------------------------------------------------------
+# Backup original state to SSD
+# ------------------------------------------------------------------
 backup_state() {
-	local env="$1" data_vol="$2" sys_vol="$3"
+	local dm="$1"
 	mkdir -p "$BACKUP_DIR"
-	step "Salvando backup em $BACKUP_DIR"
+	step "Saving backup to $BACKUP_DIR"
 
-	local hosts_path
-	hosts_path=$(get_hosts_path "$env" "$data_vol" "$sys_vol")
-	local cfg_path
-	cfg_path=$(get_cfg_path "$env" "$data_vol" "$sys_vol")
-
-	if [ -f "$hosts_path" ]; then
-		cp "$hosts_path" "$BACKUP_DIR/hosts.backup"
-		success "hosts salvo"
+	if [ -f "$dm/private/etc/hosts" ]; then
+		cp "$dm/private/etc/hosts" "$BACKUP_DIR/hosts.backup"
 	fi
-	if [ -d "$cfg_path" ]; then
+	if [ -d "$dm/private/var/db/ConfigurationProfiles/Settings" ]; then
 		mkdir -p "$BACKUP_DIR/ConfigurationProfiles"
-		cp -r "$cfg_path"/* "$BACKUP_DIR/ConfigurationProfiles/" 2>/dev/null || true
-		success "config profiles salvos"
+		cp -r "$dm/private/var/db/ConfigurationProfiles/Settings/"* "$BACKUP_DIR/ConfigurationProfiles/" 2>/dev/null || true
+	fi
+	if [ -f "$dm/private/var/db/com.apple.xpc.launchd/disabled.plist" ]; then
+		cp "$dm/private/var/db/com.apple.xpc.launchd/disabled.plist" "$BACKUP_DIR/disabled.plist.backup" 2>/dev/null || true
 	fi
 	date +%Y-%m-%d_%H-%M-%S > "$BACKUP_DIR/timestamp"
-	success "Backup concluido em $(cat "$BACKUP_DIR/timestamp")"
+	echo "$dm" > "$BACKUP_DIR/data_volume_path"
+	success "Backup saved: $(cat "$BACKUP_DIR/timestamp")"
 }
 
+# ------------------------------------------------------------------
+# Restore original state from SSD backup
+# ------------------------------------------------------------------
 restore_state() {
-	local env="$1" data_vol="$2" sys_vol="$3"
-	
 	if [ ! -f "$BACKUP_DIR/timestamp" ]; then
-		error_exit "Nenhum backup encontrado em $BACKUP_DIR"
+		error_exit "No backup found at $BACKUP_DIR"
 	fi
 
-	step "Restaurando backup de $(cat "$BACKUP_DIR/timestamp")"
-
-	local hosts_path
-	hosts_path=$(get_hosts_path "$env" "$data_vol" "$sys_vol")
-	local cfg_path
-	cfg_path=$(get_cfg_path "$env" "$data_vol" "$sys_vol")
-
-	if [ -f "$BACKUP_DIR/hosts.backup" ] && [ -f "$hosts_path" ]; then
-		sed -i '' '/# Added by bypass/d' "$hosts_path" 2>/dev/null || true
-		cp "$BACKUP_DIR/hosts.backup" "$hosts_path"
-		success "hosts restaurado"
-	fi
-	if [ -d "$BACKUP_DIR/ConfigurationProfiles" ] && [ -n "$cfg_path" ]; then
-		mkdir -p "$cfg_path"
-		cp -r "$BACKUP_DIR/ConfigurationProfiles"/* "$cfg_path/" 2>/dev/null || true
-		success "config profiles restaurados"
+	local dm
+	if [ -f "$BACKUP_DIR/data_volume_path" ]; then
+		dm=$(cat "$BACKUP_DIR/data_volume_path")
+		if [ ! -d "$dm/private/var" ]; then
+			warn "Saved Data volume path ($dm) not available. Re-detecting..."
+			dm=$(resolve_data_volume)
+		fi
+	else
+		dm=$(resolve_data_volume)
 	fi
 
-	# Re-enable daemon
-	if [ "$env" != "recovery" ]; then
-		sudo launchctl enable system/com.apple.ManagedClient.enroll 2>/dev/null || true
-		sudo launchctl enable system/com.apple.mdmclient.daemon.runatboot 2>/dev/null || true
-		success "daemons reativados"
+	step "Restoring from backup ($(cat "$BACKUP_DIR/timestamp"))"
+	echo -e "${YEL}Target Data volume: $dm${NC}"
+
+	# Restore hosts
+	if [ -f "$BACKUP_DIR/hosts.backup" ]; then
+		cp "$BACKUP_DIR/hosts.backup" "$dm/private/etc/hosts"
+		success "hosts restored"
 	fi
 
+	# Restore config profiles markers
+	if [ -d "$BACKUP_DIR/ConfigurationProfiles" ]; then
+		local cfg="$dm/private/var/db/ConfigurationProfiles/Settings"
+		mkdir -p "$cfg"
+		cp -r "$BACKUP_DIR/ConfigurationProfiles/"* "$cfg/" 2>/dev/null || true
+		success "config profiles restored"
+	fi
+
+	# Restore launchd disabled.plist
+	if [ -f "$BACKUP_DIR/disabled.plist.backup" ]; then
+		local ldp="$dm/private/var/db/com.apple.xpc.launchd/disabled.plist"
+		mkdir -p "$(dirname "$ldp")"
+		cp "$BACKUP_DIR/disabled.plist.backup" "$ldp"
+		success "launchd override restored"
+	fi
+
+	# Remove enrollment block from hosts (the lines we added)
+	if [ -f "$dm/private/etc/hosts" ]; then
+		sed -i '' '/# Added by bypass-mdm/d' "$dm/private/etc/hosts" 2>/dev/null || true
+	fi
+
+	rm -f "$BACKUP_DIR/data_volume_path"
 	rm -f "$BACKUP_DIR/timestamp"
-	success "Restauro concluido"
+	success "Restore complete"
 }
 
-block_hosts() {
-	local hosts_path="$1"
-	[ ! -f "$hosts_path" ] && touch "$hosts_path"
+# ------------------------------------------------------------------
+# Check if running in Recovery
+# ------------------------------------------------------------------
+check_recovery() {
+	if [ -d "/System/Installation" ] || [ -d "/Volumes/Macintosh HD" ] || [ -d "/Volumes/MacOS" ]; then
+		return 0
+	fi
+	# Check if we're on a recovery volume
+	local vol
+	vol=$(diskutil info / 2>/dev/null | awk -F': *' '/Volume Name/{print $2}' | xargs)
+	case "$vol" in
+		"Recovery"*|"macOS Base"*) return 0 ;;
+	esac
+	return 1
+}
 
-	grep -q "Added by bypass-mdm" "$hosts_path" 2>/dev/null || {
-		echo "" >>"$hosts_path"
-		echo "# Added by bypass-mdm — DEP enrollment block" >>"$hosts_path"
+# ------------------------------------------------------------------
+# Core suppression logic (same across all modes)
+# ------------------------------------------------------------------
+suppress_enrollment() {
+	local dm="$1"
+
+	step "Reading existing DEP record..."
+	local mdm_host="" org=""
+	local cfg="$dm/private/var/db/ConfigurationProfiles/Settings"
+	if [ -f "$cfg/.cloudConfigRecordFound" ]; then
+		mdm_host=$(plutil -convert xml1 -o - "$cfg/.cloudConfigRecordFound" 2>/dev/null \
+			| grep -ioE 'https?://[a-z0-9._-]+' | sed -E 's#https?://##' \
+			| sort -u | grep -viE '(^|\.)apple\.com$' | head -1)
+		org=$(plutil -convert xml1 -o - "$cfg/.cloudConfigRecordFound" 2>/dev/null \
+			| grep -iA1 OrganizationName | tail -1 | sed -E 's/.*<string>(.*)<\/string>.*/\1/')
+		[ -n "$org" ]      && info "Device assigned to: $org"
+		[ -n "$mdm_host" ] && info "Org MDM host: $mdm_host"
+	else
+		info "No DEP activation record found."
+	fi
+	echo ""
+
+	# Block domains
+	step "Blocking enrollment domains..."
+	local hosts="$dm/private/etc/hosts"
+	[ -f "$hosts" ] || { mkdir -p "$(dirname "$hosts")"; touch "$hosts"; }
+	grep -q "Added by bypass-mdm" "$hosts" 2>/dev/null || {
+		echo "" >>"$hosts"
+		echo "# Added by bypass-mdm — DEP enrollment block" >>"$hosts"
 	}
-
-	local domains=(
-		iprofiles.apple.com
-		deviceenrollment.apple.com
-		mdmenrollment.apple.com
-		acmdm.apple.com
-	)
+	local domains=(iprofiles.apple.com deviceenrollment.apple.com mdmenrollment.apple.com acmdm.apple.com)
+	[ -n "$mdm_host" ] && domains+=("$mdm_host")
 	local d
 	for d in "${domains[@]}"; do
-		grep -qiE "[[:space:]]$d(\$|[[:space:]])" "$hosts_path" 2>/dev/null && continue
-		printf '0.0.0.0 %s\n::      %s\n' "$d" "$d" >>"$hosts_path"
-		success "bloqueado $d"
+		grep -qiE "[[:space:]]$d(\$|[[:space:]])" "$hosts" 2>/dev/null && { info "$d already blocked"; continue; }
+		printf '0.0.0.0 %s\n::      %s\n' "$d" "$d" >>"$hosts"
+		success "blocked $d"
 	done
-}
+	echo ""
 
-reset_markers() {
-	local cfg_path="$1"
-	[ -z "$cfg_path" ] && return 1
-	mkdir -p "$cfg_path"
-	rm -f "$cfg_path/.cloudConfigHasActivationRecord" \
-	      "$cfg_path/.cloudConfigRecordFound" \
-	      "$cfg_path/.cloudConfigTimerCheck" \
-	      "$cfg_path/com.apple.mdm.depnag.plist" \
-	      "$cfg_path/com.apple.mdm.prelogin.plist" 2>/dev/null
-	touch "$cfg_path/.cloudConfigRecordNotFound" \
-	      "$cfg_path/.cloudConfigProfileInstalled"
-	success "marcadores resetados"
-}
+	# Reset markers
+	step "Resetting DEP markers..."
+	mkdir -p "$cfg"
+	rm -f "$cfg/.cloudConfigHasActivationRecord" \
+	      "$cfg/.cloudConfigRecordFound" \
+	      "$cfg/.cloudConfigTimerCheck" 2>/dev/null
+	touch "$cfg/.cloudConfigRecordNotFound" \
+	      "$cfg/.cloudConfigProfileInstalled"
+	success "Markers reset"
 
-disable_daemon_launchctl() {
-	sudo launchctl disable system/com.apple.ManagedClient.enroll 2>/dev/null || true
-	sudo launchctl disable system/com.apple.mdmclient.daemon.runatboot 2>/dev/null || true
-	success "daemon desativado (launchctl)"
-}
-
-disable_daemon_plist() {
-	local data_vol="$1"
-	[ -z "$data_vol" ] && return 1
-	local plist="$data_vol/private/var/db/com.apple.xpc.launchd/disabled.plist"
-	mkdir -p "$(dirname "$plist")"
-	[ -f "$plist" ] || printf '<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0"><dict/></plist>\n' >"$plist"
+	# Disable daemon via launchd override
+	step "Disabling enrollment daemon..."
+	local ldp="$dm/private/var/db/com.apple.xpc.launchd/disabled.plist"
+	mkdir -p "$(dirname "$ldp")"
+	[ -f "$ldp" ] || printf '<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0"><dict/></plist>\n' >"$ldp"
 	for label in com.apple.ManagedClient.enroll com.apple.mdmclient.daemon.runatboot; do
-		/usr/libexec/PlistBuddy -c "Add :$label bool true" "$plist" 2>/dev/null \
-			|| /usr/libexec/PlistBuddy -c "Set :$label true" "$plist" 2>/dev/null
+		$PB -c "Add :$label bool true" "$ldp" 2>/dev/null \
+			|| $PB -c "Set :$label true" "$ldp" 2>/dev/null
 	done
-	success "daemon desativado (plist override)"
+	success "Daemon disabled"
+
+	# Mark setup as done (for fresh install scenario)
+	touch "$dm/private/var/db/.AppleSetupDone" 2>/dev/null || true
 }
 
-create_user_recovery() {
-	local data_vol="$1"
-	[ -z "$data_vol" ] && error_exit "Volume de dados nao encontrado"
-
-	local dscl_path="$data_vol/private/var/db/dslocal/nodes/Default"
-	[ ! -d "$dscl_path" ] && error_exit "Diretorio de usuarios nao encontrado em $dscl_path"
-
-	read -p "Nome completo (padrao 'Apple'): " realName; realName="${realName:=Apple}"
-	read -p "Nome de usuario (padrao 'Apple'): " username; username="${username:=Apple}"
-	read -p "Senha (padrao '1234'): " passw; passw="${passw:=1234}"
-
-	step "Criando usuario $username"
-	dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" 2>/dev/null || true
-	dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" UserShell "/bin/zsh" 2>/dev/null
-	dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" RealName "$realName" 2>/dev/null
-	dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" UniqueID "501" 2>/dev/null
-	dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" PrimaryGroupID "20" 2>/dev/null
-	dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" NFSHomeDirectory "/Users/$username" 2>/dev/null
-	dscl -f "$dscl_path" localhost -passwd  "/Local/Default/Users/$username" "$passw" 2>/dev/null || warn "Falha ao definir senha"
-	dscl -f "$dscl_path" localhost -append  "/Local/Default/Groups/admin" GroupMembership "$username" 2>/dev/null || true
-	mkdir -p "$data_vol/Users/$username"
-	touch "$data_vol/private/var/db/.AppleSetupDone"
-	success "Usuario $username criado. Login: $username / $passw"
-}
-
-# ============================================================
-# MAIN
-# ============================================================
-env=$(detect_environment)
-data_vol=$(find_data_volume)
-sys_vol=""
-[ -n "$data_vol" ] && sys_vol=$(find_system_volume "$data_vol")
-
+# ------------------------------------------------------------------
+# Main
+# ------------------------------------------------------------------
 echo ""
-echo -e "${CYAN}============================================${NC}"
-echo -e "${CYAN}   Bypass MDM Express                      ${NC}"
-echo -e "${CYAN}============================================${NC}"
-echo ""
-echo -e "${BLU}Modo detectado:${NC} $env"
-[ -n "$data_vol" ] && echo -e "${BLU}Volume dados:${NC} $data_vol"
-[ -n "$sys_vol" ]  && echo -e "${BLU}Volume sistema:${NC} $sys_vol"
+echo -e "${CYAN}==============================================${NC}"
+echo -e "${CYAN}   Bypass MDM Express                        ${NC}"
+echo -e "${CYAN}   All-in-one: backup + bypass + restore     ${NC}"
+echo -e "${CYAN}==============================================${NC}"
 echo ""
 
-PS3="Escolha uma opcao: "
+if ! check_recovery; then
+	warn "This script should be run from Recovery mode."
+	warn "Restart and hold Power (Apple Silicon) or CMD+R (Intel)."
+	echo ""
+	read -p "Continue anyway? (y/N): " force
+	[[ "$force" =~ ^[Yy]$ ]] || exit 1
+fi
+
+data_mount=$(resolve_data_volume)
+echo ""
+
+PS3="Choose an option: "
 options=(
-	"Backup + Bypass MDM (recomendado)"
-	"Restore (voltar ao estado original)"
-	"Checar status do MDM"
-	"Sair"
+	"Backup + Bypass MDM (safe, reversible)"
+	"Restore original state (from backup)"
+	"Check current MDM status"
+	"Exit"
 )
 select opt in "${options[@]}"; do
 	case $opt in
-	"Backup + Bypass MDM (recomendado)")
+	"Backup + Bypass MDM (safe, reversible)")
 		echo ""
-
-		backup_state "$env" "$data_vol" "$sys_vol"
+		backup_state "$data_mount"
 		echo ""
-
-		hosts_path=$(get_hosts_path "$env" "$data_vol" "$sys_vol")
-		cfg_path=$(get_cfg_path "$env" "$data_vol" "$sys_vol")
-
-		if [ "$env" = "recovery" ]; then
-			step "Modo Recovery — bypass completo"
-			block_hosts "$hosts_path"
-			reset_markers "$cfg_path"
-			disable_daemon_plist "$data_vol" "$sys_vol"
-
-			echo ""
-			echo -e "${YEL}Criar usuario admin temporario?${NC}"
-			read -p "Se for setup novo (tela de enrolamento), digite 's' [s/N]: " create_user
-			if [[ "$create_user" =~ ^[Ss]$ ]]; then
-				create_user_recovery "$data_vol"
-			fi
-		else
-			step "Modo normal — bypass parcial (SIP $([ "$env" = "normal_sip_on" ] && echo "ATIVADO" || echo "DESATIVADO"))"
-			[ "$env" = "normal_sip_off" ] && warn "SIP desativado: escrita extra disponivel" || warn "SIP ativado: apenas bloqueio de dominios e launchctl"
-			
-			if [ -w "$hosts_path" ] || [ "$EUID" -eq 0 ]; then
-				block_hosts "$hosts_path"
-			else
-				warn "Sem permissao para escrever em $hosts_path (tente com sudo)"
-			fi
-
-			if [ "$env" != "normal_sip_on" ] && [ -n "$cfg_path" ]; then
-				reset_markers "$cfg_path"
-			fi
-
-			disable_daemon_launchctl
-		fi
-
+		suppress_enrollment "$data_mount"
 		echo ""
-		echo -e "${GRN}============================================${NC}"
-		echo -e "${GRN}  Pronto! Backup salvo em $BACKUP_DIR        ${NC}"
-		echo -e "${GRN}  Para restaurar: rode este script denovo   ${NC}"
-		echo -e "${GRN}  e escolha 'Restore'                       ${NC}"
-		echo -e "${GRN}============================================${NC}"
+		echo -e "${GRN}==============================================${NC}"
+		echo -e "${GRN}  Done! Backup saved to $BACKUP_DIR${NC}"
+		echo -e "${GRN}  To restore: re-run and pick option 2${NC}"
+		echo -e "${GRN}  Reboot your Mac now.${NC}"
+		echo -e "${GRN}==============================================${NC}"
 		break
 		;;
-
-	"Restore (voltar ao estado original)")
+	"Restore original state (from backup)")
 		echo ""
-		restore_state "$env" "$data_vol" "$sys_vol"
-		echo -e "${GRN}Estado original restaurado.${NC}"
+		restore_state
+		echo ""
+		echo -e "${GRN}Original state restored. Reboot to apply.${NC}"
 		break
 		;;
-
-	"Checar status do MDM")
+	"Check current MDM status")
 		echo ""
-		step "Checando enrolamento DEP..."
 		if command -v profiles &>/dev/null; then
-			profiles status -type enrollment 2>/dev/null || warn "nao foi possivel checar"
+			profiles status -type enrollment 2>/dev/null || warn "Could not check enrollment status"
 		else
-			warn "comando 'profiles' nao disponivel (rode do Recovery ou macOS normal)"
+			warn "'profiles' command not available"
 		fi
-
-		step "Hosts bloqueados:"
-		hosts_path=$(get_hosts_path "$env" "$data_vol" "$sys_vol")
-		if [ -f "$hosts_path" ]; then
-			grep -iE 'iprofiles|enrollment|mdm|acmdm' "$hosts_path" 2>/dev/null || echo "  (nenhum)"
+		echo ""
+		step "Blocked domains in hosts:"
+		if [ -f "$data_mount/private/etc/hosts" ]; then
+			grep -iE 'iprofiles|enrollment|mdm|acmdm' "$data_mount/private/etc/hosts" 2>/dev/null || echo "  (none)"
 		fi
-
-		step "Backup existente:"
+		echo ""
+		step "Existing backup:"
 		if [ -f "$BACKUP_DIR/timestamp" ]; then
 			echo "  $(cat "$BACKUP_DIR/timestamp")"
 		else
-			echo "  (nenhum)"
+			echo "  (none)"
 		fi
-		echo ""
 		break
 		;;
-
-	"Sair")
-		exit 0
-		;;
-	*) echo -e "${RED}Opcao invalida $REPLY${NC}" ;;
+	"Exit") exit 0 ;;
+	*) echo -e "${RED}Invalid option $REPLY${NC}" ;;
 	esac
 done

--- a/bypass-mdm-v2.sh
+++ b/bypass-mdm-v2.sh
@@ -1,84 +1,129 @@
 #!/bin/bash
+set -euo pipefail
 
-# Define color codes
+# bypamd-mdm-v2.sh -- DEP/MDM enrollment suppression for macOS.
+# IMPORTANT: On Apple Silicon / macOS 11+, the OS boots from a sealed,
+# read-only System Volume. The live /etc/hosts and /var/db/ConfigurationProfiles
+# actually live on the Data volume (via /private firmlink). This script writes
+# to the Data volume paths, which is correct for both Intel and Apple Silicon.
+#
+# For a more robust solution with FileVault support, launchd override, and
+# macOS 26 support, use bypass-mdm-v3.sh.
+#
+# RUN FROM RECOVERY (Apple Silicon: hold Power -> Options -> Utilities ->
+# Terminal). Use responsibly, on devices you own.
+
 RED='\033[1;31m'
 GRN='\033[1;32m'
 BLU='\033[1;34m'
 YEL='\033[1;33m'
-PUR='\033[1;35m'
 CYAN='\033[1;36m'
 NC='\033[0m'
 
-# Function to get the system volume name
+error_exit() { echo -e "${RED}ERROR: $1${NC}" >&2; exit 1; }
+success()    { echo -e "${GRN}\u2713 $1${NC}"; }
+info()       { echo -e "${BLU}\u2139 $1${NC}"; }
+
 get_system_volume() {
-    system_volume=$(diskutil info / | grep "Device Node" | awk -F': ' '{print $2}' | xargs diskutil info | grep "Volume Name" | awk -F': ' '{print $2}' | tr -d ' ')
-    echo "$system_volume"
+	diskutil info / | grep "Volume Name:" | awk -F': ' '{print $2}' | xargs
 }
 
-# Get the system volume name
 system_volume=$(get_system_volume)
+data_volume="${system_volume} - Data"
 
-# Display header
-echo -e "${CYAN}Bypass MDM By Assaf Dori (assafdori.com)${NC}"
+# If the standard "- Data" volume doesn't exist, try "Data"
+if [ ! -d "/Volumes/$data_volume" ] && [ -d "/Volumes/Data" ]; then
+	data_volume="Data"
+fi
+
+if [ ! -d "/Volumes/$data_volume" ]; then
+	error_exit "Data volume not found. Ensure you're in Recovery mode."
+fi
+
+# Normalize data volume name for consistency
+if [ "$data_volume" != "Data" ]; then
+	diskutil rename "$data_volume" "Data" 2>/dev/null || true
+	data_volume="Data"
+fi
+
+echo ""
+echo -e "${CYAN}Bypass MDM v2${NC}"
+success "System volume: $system_volume"
+success "Data volume: $data_volume"
 echo ""
 
-# Prompt user for choice
 PS3='Please enter your choice: '
 options=("Bypass MDM from Recovery" "Reboot & Exit")
 select opt in "${options[@]}"; do
-    case $opt in
-        "Bypass MDM from Recovery")
-            # Bypass MDM from Recovery
-            echo -e "${YEL}Bypass MDM from Recovery"
-            if [ -d "/Volumes/$system_volume - Data" ]; then
-                diskutil rename "$system_volume - Data" "Data"
-            fi
+	case $opt in
+	"Bypass MDM from Recovery")
+		echo ""
+		info "Starting MDM Bypass..."
+		echo ""
 
-            # Create Temporary User
-            echo -e "${NC}Create a Temporary User"
-            read -p "Enter Temporary Fullname (Default is 'Apple'): " realName
-            realName="${realName:=Apple}"
-            read -p "Enter Temporary Username (Default is 'Apple'): " username
-            username="${username:=Apple}"
-            read -p "Enter Temporary Password (Default is '1234'): " passw
-            passw="${passw:=1234}"
+		# Create Temporary User on the Data volume
+		echo -e "${NC}Create a Temporary Admin User${NC}"
+		read -p "Enter Temporary Fullname (Default is 'Apple'): " realName
+		realName="${realName:=Apple}"
+		read -p "Enter Temporary Username (Default is 'Apple'): " username
+		username="${username:=Apple}"
+		read -p "Enter Temporary Password (Default is '1234'): " passw
+		passw="${passw:=1234}"
 
-            # Create User
-            dscl_path='/Volumes/Data/private/var/db/dslocal/nodes/Default'
-            echo -e "${GREEN}Creating Temporary User"
-            dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username"
-            dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" UserShell "/bin/zsh"
-            dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" RealName "$realName"
-            dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" UniqueID "501"
-            dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" PrimaryGroupID "20"
-            mkdir "/Volumes/Data/Users/$username"
-            dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" NFSHomeDirectory "/Users/$username"
-            dscl -f "$dscl_path" localhost -passwd "/Local/Default/Users/$username" "$passw"
-            dscl -f "$dscl_path" localhost -append "/Local/Default/Groups/admin" GroupMembership $username
+		dscl_path="/Volumes/Data/private/var/db/dslocal/nodes/Default"
+		if [ ! -d "$dscl_path" ]; then
+			error_exit "Directory Services path not found: $dscl_path"
+		fi
 
-            # Block MDM domains
-            echo "0.0.0.0 deviceenrollment.apple.com" >>/Volumes/"$system_volume"/etc/hosts
-            echo "0.0.0.0 mdmenrollment.apple.com" >>/Volumes/"$system_volume"/etc/hosts
-            echo "0.0.0.0 iprofiles.apple.com" >>/Volumes/"$system_volume"/etc/hosts
-            echo -e "${GRN}Successfully blocked MDM & Profile Domains"
+		info "Creating user account: $username"
+		dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username"
+		dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" UserShell "/bin/zsh"
+		dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" RealName "$realName"
+		dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" UniqueID "501"
+		dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" PrimaryGroupID "20"
+		mkdir -p "/Volumes/Data/Users/$username"
+		dscl -f "$dscl_path" localhost -create "/Local/Default/Users/$username" NFSHomeDirectory "/Users/$username"
+		dscl -f "$dscl_path" localhost -passwd "/Local/Default/Users/$username" "$passw"
+		dscl -f "$dscl_path" localhost -append "/Local/Default/Groups/admin" GroupMembership "$username"
+		success "Admin account created"
 
-            # Remove configuration profiles
-            touch /Volumes/Data/private/var/db/.AppleSetupDone
-            rm -rf /Volumes/"$system_volume"/var/db/ConfigurationProfiles/Settings/.cloudConfigHasActivationRecord
-            rm -rf /Volumes/"$system_volume"/var/db/ConfigurationProfiles/Settings/.cloudConfigRecordFound
-            touch /Volumes/"$system_volume"/var/db/ConfigurationProfiles/Settings/.cloudConfigProfileInstalled
-            touch /Volumes/"$system_volume"/var/db/ConfigurationProfiles/Settings/.cloudConfigRecordNotFound
+		# Block MDM domains on the DATA volume's hosts file (SSV-safe)
+		info "Blocking MDM domains..."
+		hosts_file="/Volumes/Data/private/etc/hosts"
+		[ -f "$hosts_file" ] || touch "$hosts_file"
+		grep -q "deviceenrollment.apple.com" "$hosts_file" 2>/dev/null \
+			|| echo "0.0.0.0 deviceenrollment.apple.com" >>"$hosts_file"
+		grep -q "mdmenrollment.apple.com" "$hosts_file" 2>/dev/null \
+			|| echo "0.0.0.0 mdmenrollment.apple.com" >>"$hosts_file"
+		grep -q "iprofiles.apple.com" "$hosts_file" 2>/dev/null \
+			|| echo "0.0.0.0 iprofiles.apple.com" >>"$hosts_file"
+		success "MDM domains blocked"
 
-            echo -e "${GRN}MDM enrollment has been bypassed!${NC}"
-            echo -e "${NC}Exit terminal and reboot your Mac.${NC}"
-            break
-            ;;
-        "Reboot & Exit")
-            # Reboot & Exit
-            echo "Rebooting..."
-            reboot
-            break
-            ;;
-        *) echo "Invalid option $REPLY" ;;
-    esac
+		# Remove configuration profiles on the DATA volume
+		info "Resetting enrollment markers..."
+		config_path="/Volumes/Data/private/var/db/ConfigurationProfiles/Settings"
+		mkdir -p "$config_path"
+		rm -f "$config_path/.cloudConfigHasActivationRecord" \
+		      "$config_path/.cloudConfigRecordFound"
+		touch "$config_path/.cloudConfigProfileInstalled" \
+		      "$config_path/.cloudConfigRecordNotFound"
+		touch "/Volumes/Data/private/var/db/.AppleSetupDone"
+		success "Configuration profiles reset"
+
+		echo ""
+		echo -e "${GRN}============================================${NC}"
+		echo -e "${GRN}       MDM Bypass Completed Successfully!    ${NC}"
+		echo -e "${GRN}============================================${NC}"
+		echo ""
+		echo -e "${CYAN}Login after reboot:${NC} ${YEL}$username${NC} / ${YEL}$passw${NC}"
+		echo ""
+		break
+		;;
+	"Reboot & Exit")
+		info "Rebooting..."
+		reboot
+		break
+		;;
+	*) echo -e "${RED}Invalid option $REPLY${NC}" ;;
+	esac
 done

--- a/bypass-mdm-v3.sh
+++ b/bypass-mdm-v3.sh
@@ -1,0 +1,322 @@
+#!/bin/bash
+set -euo pipefail
+
+# bypass-mdm-v3.sh — DEP/MDM enrollment suppression for macOS, hardened for
+# Apple Silicon + Signed System Volume (macOS 11 Big Sur .. 26 Tahoe).
+#
+# TWO MODES:
+#   · Suppress enrollment only  — for a Mac that is ALREADY SET UP and just
+#     nags you to enroll. Blocks the enrollment fetch, clears the cached DEP
+#     record, and disables the enrollment daemon. Does NOT create any user.
+#   · Full bypass               — for a Mac stuck at the Remote Management /
+#     Setup Assistant screen. Also creates a temp local admin + .AppleSetupDone
+#     so first boot skips Setup Assistant, then runs the same suppression.
+#
+# WHY v3 EXISTS (what was broken in v1/v2 on modern macOS):
+#   1. v1/v2 wrote /etc/hosts and the ConfigurationProfiles markers to the
+#      *System* volume. On Apple Silicon the OS boots from a sealed, read-only
+#      snapshot; the live /etc/hosts and /var/db/ConfigurationProfiles actually
+#      live on the *Data* volume (via /etc -> /private/etc, /var -> /private/var,
+#      and the /private firmlink). Those writes never reached the running OS.
+#      THIS IS THE MAIN FIX: everything is written to the Data volume.
+#   2. FileVault is on by default, so in Recovery the Data volume is LOCKED and
+#      not auto-mounted (v2's "Could not detect data volume"). v3 finds it by
+#      APFS role and unlocks it.
+#   3. Markers alone aren't durable: macOS re-fetches the record from Apple after
+#      an update. v3 also blocks iprofiles.apple.com + the org's own MDM host,
+#      and disables the enrollment daemon via a launchd override ON THE DATA
+#      VOLUME (survives the System-volume reseal an update performs).
+#   4. cloudconfigurationd no longer exists on macOS 26 — the work moved to
+#      com.apple.ManagedClient.enroll. v3 targets the current daemon names.
+#
+# HARD LIMIT: this does NOT remove your device from the organization's Apple
+# Business/School Manager. The record is keyed to your serial and re-fetched
+# whenever the Mac reaches Apple. This only SUPPRESSES enrollment locally; the
+# permanent fix is the owning org releasing your serial in ABM. Never run
+# `profiles renew`, and avoid Erase All Content & Settings / factory reset.
+#
+# RUN FROM RECOVERY (Apple Silicon: hold Power -> Options -> Utilities ->
+# Terminal). Use responsibly, on devices you own.
+
+RED='\033[1;31m'
+GRN='\033[1;32m'
+BLU='\033[1;34m'
+YEL='\033[1;33m'
+CYAN='\033[1;36m'
+NC='\033[0m'
+
+error_exit() { echo -e "${RED}ERROR: $1${NC}" >&2; exit 1; }
+warn()       { echo -e "${YEL}WARNING: $1${NC}" >&2; }
+success()    { echo -e "${GRN}\u2713 $1${NC}"; }
+info()       { echo -e "${BLU}\u2139 $1${NC}"; }
+step()       { echo -e "${CYAN}\u25b8 $1${NC}"; }
+
+PB=/usr/libexec/PlistBuddy
+
+# ------------------------------------------------------------------
+# Input validation
+# ------------------------------------------------------------------
+validate_username() {
+	local u="$1"
+	[ -z "$u" ] && { echo "Username cannot be empty" >&2; return 1; }
+	[ ${#u} -gt 31 ] && { echo "Username too long (max 31 chars)" >&2; return 1; }
+	[[ "$u" =~ ^[a-zA-Z0-9_-]+$ ]] || { echo "Use only letters, numbers, _ and -" >&2; return 1; }
+	[[ "$u" =~ ^[a-zA-Z_] ]] || { echo "Must start with a letter or underscore" >&2; return 1; }
+	return 0
+}
+
+validate_password() {
+	[ -z "$1" ] && { echo "Password cannot be empty" >&2; return 1; }
+	[ ${#1} -lt 4 ] && { echo "Password too short (min 4 chars)" >&2; return 1; }
+	return 0
+}
+
+# ------------------------------------------------------------------
+# Locate and mount the Data volume by APFS role.
+# Multi-strategy: (1) awk regex, (2) literal name, (3) user prompt.
+# Fallback chain: mount -> FileVault unlock.
+# Echoes the mount point on stdout; all messages go to stderr.
+# ------------------------------------------------------------------
+resolve_data_volume() {
+	step "Locating the Data volume by APFS role..."
+
+	local id mount_pt
+
+	id=$(diskutil apfs list 2>/dev/null \
+		| awk '/\(Data\)/ && match($0, /disk[0-9]+s[0-9]+/) {print substr($0, RSTART, RLENGTH); exit}')
+
+	if [ -z "$id" ] || ! diskutil info "/dev/$id" >/dev/null 2>&1; then
+		info "Could not identify Data volume by role — trying name-based detection..."
+		id=$(diskutil list 2>/dev/null \
+			| awk '/[[:space:]]Data[[:space:]]/{for(i=1;i<=NF;i++) if($i ~ /^disk[0-9]+s[0-9]+$/) v=$i} END{print v}')
+	fi
+
+	if [ -z "$id" ] || ! diskutil info "/dev/$id" >/dev/null 2>&1; then
+		warn "Could not auto-detect the Data volume. Available disks:"
+		diskutil list >&2
+		echo ""
+		read -p "Type the Data volume identifier (e.g. disk3s1): " id </dev/tty
+		id="${id#/dev/}"
+	fi
+
+	[ -n "$id" ] || error_exit "No Data volume identifier provided."
+	local data_dev="/dev/$id"
+	diskutil info "$data_dev" >/dev/null 2>&1 || error_exit "Not a valid disk: $data_dev"
+	info "Data volume device: $data_dev"
+
+	_mount_point() { diskutil info "$data_dev" 2>/dev/null | awk -F': *' '/Mount Point/{print $2}' | sed 's/[[:space:]]*$//'; }
+
+	mount_pt=$(_mount_point)
+
+	if [ -z "$mount_pt" ] || [ ! -d "$mount_pt" ]; then
+		info "Data volume not mounted — mounting..."
+		diskutil mount "$data_dev" 2>/dev/null || true
+		mount_pt=$(_mount_point)
+	fi
+
+	if [ -z "$mount_pt" ] || [ ! -d "$mount_pt" ]; then
+		warn "Data volume is FileVault-locked — need to unlock."
+		echo -e "${YEL}Enter the password of an account on this Mac (or FileVault recovery key):${NC}" >&2
+		diskutil apfs unlockVolume "$data_dev" 2>/dev/null \
+			|| error_exit "Failed to unlock Data volume. Re-run with a valid password or recovery key."
+		mount_pt=$(_mount_point)
+	fi
+
+	[ -d "$mount_pt" ] || error_exit "Data volume mount point not found after mount/unlock."
+
+	if [ ! -d "$mount_pt/private/var/db/dslocal/nodes/Default" ]; then
+		error_exit "This does not look like a macOS Data volume (no dslocal node at $mount_pt)."
+	fi
+
+	success "Data volume mounted at: $mount_pt"
+	echo "$mount_pt"
+}
+
+check_user_exists() {
+	dscl -f "$1/private/var/db/dslocal/nodes/Default" localhost -read "/Local/Default/Users/$2" >/dev/null 2>&1
+}
+
+find_available_uid() {
+	local node="$1/private/var/db/dslocal/nodes/Default" uid=501
+	while [ $uid -lt 600 ]; do
+		dscl -f "$node" localhost -search /Local/Default/Users UniqueID $uid 2>/dev/null | grep -q "UniqueID" || { echo $uid; return 0; }
+		uid=$((uid + 1))
+	done
+	echo 501
+}
+
+# ------------------------------------------------------------------
+# Core enrollment block (shared by both modes).
+# Uses global paths: CFG, HOSTS, LAUNCHD_DISABLED.
+# ------------------------------------------------------------------
+suppress_enrollment() {
+	step "Inspecting the existing DEP activation record"
+	local mdm_host="" org=""
+	if [ -f "$CFG/.cloudConfigRecordFound" ]; then
+		mdm_host=$(plutil -convert xml1 -o - "$CFG/.cloudConfigRecordFound" 2>/dev/null \
+			| grep -ioE 'https?://[a-z0-9._-]+' | sed -E 's#https?://##' \
+			| sort -u | grep -viE '(^|\.)apple\.com$' | head -1)
+		org=$(plutil -convert xml1 -o - "$CFG/.cloudConfigRecordFound" 2>/dev/null \
+			| grep -iA1 OrganizationName | tail -1 | sed -E 's/.*<string>(.*)<\/string>.*/\1/')
+		[ -n "$org" ]      && info "This device is assigned in Apple Business Manager to: $org"
+		[ -n "$mdm_host" ] && info "Org MDM server host: $mdm_host (will also be blocked)"
+	else
+		info "No activation record currently present."
+	fi
+	echo ""
+
+	step "Blocking DEP enrollment domains (Data-volume hosts file)"
+	[ -f "$HOSTS" ] || { mkdir -p "$(dirname "$HOSTS")"; touch "$HOSTS"; }
+	local block_domains=(
+		iprofiles.apple.com
+		deviceenrollment.apple.com
+		mdmenrollment.apple.com
+		acmdm.apple.com
+	)
+	[ -n "$mdm_host" ] && block_domains+=("$mdm_host")
+	grep -q "Added by bypass-mdm-v3" "$HOSTS" 2>/dev/null || {
+		echo "" >>"$HOSTS"
+		echo "# Added by bypass-mdm-v3 -- DEP enrollment block" >>"$HOSTS"
+	}
+	local d
+	for d in "${block_domains[@]}"; do
+		grep -qiE "[[:space:]]$d(\$|[[:space:]])" "$HOSTS" 2>/dev/null && { info "$d already blocked"; continue; }
+		printf '0.0.0.0 %s\n::      %s\n' "$d" "$d" >>"$HOSTS"
+		success "blocked $d"
+	done
+	echo ""
+
+	step "Resetting DEP markers"
+	mkdir -p "$CFG"
+	rm -f "$CFG/.cloudConfigHasActivationRecord" \
+	      "$CFG/.cloudConfigRecordFound" \
+	      "$CFG/.cloudConfigTimerCheck" \
+	      "$CFG/com.apple.mdm.depnag.plist" \
+	      "$CFG/com.apple.mdm.prelogin.plist" 2>/dev/null
+	touch "$CFG/.cloudConfigRecordNotFound" \
+	      "$CFG/.cloudConfigProfileInstalled"
+	success "Cached record removed; markers set to not-found + profile-installed"
+	echo ""
+
+	step "Disabling the enrollment daemon (durable override on Data volume)"
+	mkdir -p "$(dirname "$LAUNCHD_DISABLED")"
+	[ -f "$LAUNCHD_DISABLED" ] || printf '<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0"><dict/></plist>\n' >"$LAUNCHD_DISABLED"
+	local label
+	for label in com.apple.ManagedClient.enroll com.apple.mdmclient.daemon.runatboot; do
+		$PB -c "Add :$label bool true" "$LAUNCHD_DISABLED" 2>/dev/null \
+			|| $PB -c "Set :$label true" "$LAUNCHD_DISABLED" 2>/dev/null
+	done
+	success "Enrollment daemon disabled via $LAUNCHD_DISABLED"
+	echo ""
+}
+
+# ------------------------------------------------------------------
+# Main
+# ------------------------------------------------------------------
+data_mount=$(resolve_data_volume) || exit 1
+
+DS_NODE="$data_mount/private/var/db/dslocal/nodes/Default"
+HOSTS="$data_mount/private/etc/hosts"
+CFG="$data_mount/private/var/db/ConfigurationProfiles/Settings"
+SETUPDONE="$data_mount/private/var/db/.AppleSetupDone"
+LAUNCHD_DISABLED="$data_mount/private/var/db/com.apple.xpc.launchd/disabled.plist"
+
+echo ""
+echo -e "${CYAN}============================================${NC}"
+echo -e "${CYAN}   Bypass MDM v3 - Apple Silicon / SSV     ${NC}"
+echo -e "${CYAN}============================================${NC}"
+success "Data volume: $data_mount"
+echo ""
+
+PS3='Please enter your choice: '
+options=(
+	"Suppress enrollment only (Mac already set up)"
+	"Full bypass (create admin + suppress - for stuck setup)"
+	"Verify current state"
+	"Reboot & Exit"
+)
+select opt in "${options[@]}"; do
+	case $opt in
+	"Suppress enrollment only (Mac already set up)")
+		echo ""
+		info "Suppress-only mode: no user will be created."
+		echo ""
+		suppress_enrollment
+		echo -e "${GRN}============================================${NC}"
+		echo -e "${GRN}     Enrollment Suppressed - reboot to apply ${NC}"
+		echo -e "${GRN}============================================${NC}"
+		echo ""
+		echo -e "${CYAN}Next:${NC} reboot. The nag should be gone."
+		echo -e "${CYAN}After a macOS update:${NC} re-run this."
+		echo -e "${YEL}Never run 'profiles renew' or Erase All Content & Settings.${NC}"
+		echo ""
+		break
+		;;
+
+	"Full bypass (create admin + suppress - for stuck setup)")
+		echo ""
+		step "Creating a temporary local admin account"
+		read -p "Full name (default 'Apple'): " realName;  realName="${realName:=Apple}"
+		while true; do
+			read -p "Username (default 'Apple'): " username; username="${username:=Apple}"
+			if msg=$(validate_username "$username"); then
+				if check_user_exists "$data_mount" "$username"; then
+					warn "User '$username' already exists."; continue
+				fi
+				break
+			else warn "$msg"; fi
+		done
+		while true; do
+			read -p "Password (default '1234'): " passw; passw="${passw:=1234}"
+			if msg=$(validate_password "$passw"); then break; else warn "$msg"; fi
+		done
+
+		uid=$(find_available_uid "$data_mount")
+		info "Using UID $uid"
+		dscl -f "$DS_NODE" localhost -create "/Local/Default/Users/$username" || error_exit "Failed to create user"
+		dscl -f "$DS_NODE" localhost -create "/Local/Default/Users/$username" UserShell "/bin/zsh"
+		dscl -f "$DS_NODE" localhost -create "/Local/Default/Users/$username" RealName "$realName"
+		dscl -f "$DS_NODE" localhost -create "/Local/Default/Users/$username" UniqueID "$uid"
+		dscl -f "$DS_NODE" localhost -create "/Local/Default/Users/$username" PrimaryGroupID "20"
+		dscl -f "$DS_NODE" localhost -create "/Local/Default/Users/$username" NFSHomeDirectory "/Users/$username"
+		dscl -f "$DS_NODE" localhost -passwd  "/Local/Default/Users/$username" "$passw" || error_exit "Failed to set password"
+		dscl -f "$DS_NODE" localhost -append  "/Local/Default/Groups/admin" GroupMembership "$username" || error_exit "Failed to grant admin"
+		mkdir -p "$data_mount/Users/$username" && success "Admin '$username' created"
+
+		touch "$SETUPDONE" && success "Setup Assistant will be skipped"
+		echo ""
+
+		suppress_enrollment
+
+		echo -e "${GRN}============================================${NC}"
+		echo -e "${GRN}      MDM Bypass Applied Successfully        ${NC}"
+		echo -e "${GRN}============================================${NC}"
+		echo ""
+		echo -e "${CYAN}Login after reboot:${NC} ${YEL}$username${NC} / ${YEL}$passw${NC}"
+		echo -e "${CYAN}After a macOS update:${NC} re-run this."
+		echo -e "${YEL}Never run 'profiles renew' or Erase All Content & Settings.${NC}"
+		echo ""
+		break
+		;;
+
+	"Verify current state")
+		echo ""
+		step "Markers in $CFG"
+		ls -la "$CFG" 2>/dev/null || warn "Settings dir not found"
+		echo ""
+		step "DEP block lines in $HOSTS"
+		grep -iE 'iprofiles|enrollment|mdm|acmdm' "$HOSTS" 2>/dev/null || warn "No block lines present"
+		echo ""
+		step "launchd disable override"
+		[ -f "$LAUNCHD_DISABLED" ] && $PB -c "Print" "$LAUNCHD_DISABLED" 2>/dev/null || info "none"
+		echo ""
+		;;
+
+	"Reboot & Exit")
+		info "Rebooting..."
+		reboot
+		break
+		;;
+	*) echo -e "${RED}Invalid option $REPLY${NC}" ;;
+	esac
+done

--- a/bypass-mdm-v3.sh
+++ b/bypass-mdm-v3.sh
@@ -261,9 +261,19 @@ select opt in "${options[@]}"; do
 			read -p "Username (default 'Apple'): " username; username="${username:=Apple}"
 			if msg=$(validate_username "$username"); then
 				if check_user_exists "$data_mount" "$username"; then
-					warn "User '$username' already exists."; continue
+					warn "User '$username' already exists."
+					read -p "Delete and recreate? (y/n): " del
+					if [[ "$del" =~ ^[Yy]$ ]]; then
+						dscl -f "$DS_NODE" localhost -delete "/Local/Default/Users/$username" 2>/dev/null || true
+						rm -rf "$data_mount/Users/$username" 2>/dev/null || true
+						success "Deleted existing user '$username'"
+						break
+					else
+						warn "Choose a different username."
+					fi
+				else
+					break
 				fi
-				break
 			else warn "$msg"; fi
 		done
 		while true; do
@@ -273,17 +283,28 @@ select opt in "${options[@]}"; do
 
 		uid=$(find_available_uid "$data_mount")
 		info "Using UID $uid"
-		dscl -f "$DS_NODE" localhost -create "/Local/Default/Users/$username" || error_exit "Failed to create user"
-		dscl -f "$DS_NODE" localhost -create "/Local/Default/Users/$username" UserShell "/bin/zsh"
-		dscl -f "$DS_NODE" localhost -create "/Local/Default/Users/$username" RealName "$realName"
-		dscl -f "$DS_NODE" localhost -create "/Local/Default/Users/$username" UniqueID "$uid"
-		dscl -f "$DS_NODE" localhost -create "/Local/Default/Users/$username" PrimaryGroupID "20"
-		dscl -f "$DS_NODE" localhost -create "/Local/Default/Users/$username" NFSHomeDirectory "/Users/$username"
-		dscl -f "$DS_NODE" localhost -passwd  "/Local/Default/Users/$username" "$passw" || error_exit "Failed to set password"
-		dscl -f "$DS_NODE" localhost -append  "/Local/Default/Groups/admin" GroupMembership "$username" || error_exit "Failed to grant admin"
+
+		set +e
+		dscl -f "$DS_NODE" localhost -create "/Local/Default/Users/$username" 2>/dev/null || error_exit "Failed to create user"
+		dscl -f "$DS_NODE" localhost -create "/Local/Default/Users/$username" UserShell "/bin/zsh" 2>/dev/null
+		dscl -f "$DS_NODE" localhost -create "/Local/Default/Users/$username" RealName "$realName" 2>/dev/null
+		dscl -f "$DS_NODE" localhost -create "/Local/Default/Users/$username" UniqueID "$uid" 2>/dev/null
+		dscl -f "$DS_NODE" localhost -create "/Local/Default/Users/$username" PrimaryGroupID "20" 2>/dev/null
+		dscl -f "$DS_NODE" localhost -create "/Local/Default/Users/$username" NFSHomeDirectory "/Users/$username" 2>/dev/null
+		if ! dscl -f "$DS_NODE" localhost -passwd "/Local/Default/Users/$username" "$passw" 2>/dev/null; then
+			error_exit "Failed to set password for '$username'. The user might still exist from a previous run — delete it first."
+		fi
+		dscl -f "$DS_NODE" localhost -append "/Local/Default/Groups/admin" GroupMembership "$username" 2>/dev/null || error_exit "Failed to grant admin"
+		set -e
+
 		mkdir -p "$data_mount/Users/$username" && success "Admin '$username' created"
 
 		touch "$SETUPDONE" && success "Setup Assistant will be skipped"
+
+		# Try to add user to FileVault (fixes "user not showing on login" on 15.6+)
+		if [ -x /usr/bin/fdesetup ] && fdesetup supportsauthorizedusers 2>/dev/null | grep -q true; then
+			fdesetup add -usertoadd "$username" 2>/dev/null || true
+		fi
 		echo ""
 
 		suppress_enrollment


### PR DESCRIPTION

## What changed

### bypass-mdm-express.sh (new)
All-in-one script with backup + bypass + restore. Designed to be the simplest way to bypass MDM:
- Put it on an **external SSD**, run it from there — no curl, no downloads
- **Automatic backup** of original state before making changes
- **Restore** everything when needed (take to Apple for re-enrollment, then restore)
- Backup stored on the SSD itself (`.bypass-backup/`)
- Runs from Recovery mode (proven path)

### bypass-mdm-v3.sh (improvements)
Based on PR #170 by marclllaks with hardening:
- More robust Data volume detection (regex-based awk handles tree-drawing chars)
- `set -euo pipefail` for early error detection
- All output functions consistently use stderr (fix from PR #144)
- **Detects existing user** and offers to delete/recreate (fixes #84)
- **Adds user to FileVault** via fdesetup (fixes #88)
- Uses `set +e` on critical dscl blocks to avoid aborting on minor errors

### bypass-mdm-v2.sh (critical fix)
- **SSV fix**: now writes to Data volume paths (`/Volumes/Data/private/etc/hosts`) instead of System volume
- Same fix for ConfigurationProfiles paths
- `set -euo pipefail`

### bypass-mdm-dualboot.sh (bug fixes)
- Typo: Machintosh -> Macintosh
- Missing `/var/` in ConfigurationProfiles path fixed
- Color code fixed (RED -> NC)
- SSV fix: writes to Data volume on the target installation

### README.md
- Unified in English
- Comparison table for all 5 scripts
- Express script instructions
